### PR TITLE
Add helper lists management

### DIFF
--- a/www.technology.gr/coder/calendar.php
+++ b/www.technology.gr/coder/calendar.php
@@ -36,9 +36,10 @@ main{flex:1;}
 header{padding:1em;background:#333;color:#fff;text-align:center;}
 footer{padding:.3em;background:#333;color:#fff;font-size:12px;text-align:left;}
 table{border-collapse:collapse;width:100%;}
-th,td{border:1px solid #ccc;padding:5px;height:80px;vertical-align:top;width:14.28%;}
-td strong{font-size:28px;color:#000;}
 .entries{font-size:12px;line-height:1.2;}
+th,td{border:1px solid #ccc;padding:5px;height:80px;vertical-align:top;width:14.28%;}
+td > strong{font-size:28px;color:#000;}
+.entries strong{font-size:inherit;}
 td a{color:#000;text-decoration:none;}
 th{background:#f0f0f0;}
 @media(max-width:600px){th,td{height:auto;font-size:12px;}}

--- a/www.technology.gr/coder/calendar.php
+++ b/www.technology.gr/coder/calendar.php
@@ -38,6 +38,7 @@ footer{padding:.3em;background:#333;color:#fff;font-size:12px;text-align:left;}
 table{border-collapse:collapse;width:100%;}
 th,td{border:1px solid #ccc;padding:5px;height:80px;vertical-align:top;width:14.28%;}
 td strong{font-size:28px;color:#000;}
+.entries{font-size:12px;line-height:1.2;}
 td a{color:#000;text-decoration:none;}
 th{background:#f0f0f0;}
 @media(max-width:600px){th,td{height:auto;font-size:12px;}}
@@ -68,7 +69,7 @@ $d=1;$i=$dayOfWeek;
 while($d<=$daysInMonth){
     if($i==8){echo '</tr><tr>';$i=1;}
     $linkDate = sprintf('%04d-%02d-%02d',$year,$month,$d);
-    echo '<td><a href="record.php?service_date='.$linkDate.'"><strong>'.$d.'</strong></a><br>';
+    echo '<td><a href="record.php?service_date='.$linkDate.'"><strong>'.$d.'</strong></a><br><div class="entries">';
     if(isset($records[$d])){
         foreach($records[$d] as $rec){
             $lic = htmlspecialchars($rec['license']);
@@ -83,7 +84,7 @@ while($d<=$daysInMonth){
             echo '<span style="color:green;font-weight:bold;">'.$disp.'</span><br>';
         }
     }
-    echo '</td>';
+    echo '</div></td>';
     $d++;$i++;}
 for(;$i<=7;$i++)echo '<td></td>';
 ?>

--- a/www.technology.gr/coder/calendar.php
+++ b/www.technology.gr/coder/calendar.php
@@ -36,6 +36,7 @@ header{padding:1em;background:#333;color:#fff;text-align:center;}
 footer{padding:.3em;background:#333;color:#fff;font-size:12px;text-align:left;}
 table{border-collapse:collapse;width:100%;}
 th,td{border:1px solid #ccc;padding:5px;height:80px;vertical-align:top;width:14.28%;}
+td strong{font-size:14px;}
 th{background:#f0f0f0;}
 @media(max-width:600px){th,td{height:auto;font-size:12px;}}
 nav a{margin-right:10px;}
@@ -46,7 +47,7 @@ nav a{margin-right:10px;}
     <h1>Εργασίες Οχημάτων</h1>
     <nav>
         <a href="index.php" style="color:#fff;margin-right:10px;">Αρχική</a>
-        <a href="record.php" style="color:#fff;margin-right:10px;">Νέα Καταχώρηση</a>
+        <a href="record.php" style="color:#fff;margin-right:10px;">Νέα Καταχώριση</a>
         <a href="calendar.php" style="color:#fff;margin-right:10px;">Ημερολόγιο</a>
         <a href="helpers.php" style="color:#fff;">Βοηθητικά</a>
     </nav>
@@ -54,8 +55,8 @@ nav a{margin-right:10px;}
 <main>
 <h2 style="text-align:center;"><?= mb_strtoupper($months_gr[$month], 'UTF-8').' '. $year ?></h2>
 <div style="text-align:center;margin-bottom:1em;">
-<a href="?month=<?=$prevMonth?>&year=<?=$prevYear?>">&laquo;</a>
-<a href="?month=<?=$nextMonth?>&year=<?=$nextYear?>">&raquo;</a>
+<a href="?month=<?=$prevMonth?>&year=<?=$prevYear?>" style="font-size:20px;margin-right:20px;">&#9664;</a>
+<a href="?month=<?=$nextMonth?>&year=<?=$nextYear?>" style="font-size:20px;margin-left:20px;">&#9654;</a>
 </div>
 <table>
 <tr><th>Δευ</th><th>Τρι</th><th>Τετ</th><th>Πεμ</th><th>Παρ</th><th>Σαβ</th><th>Κυρ</th></tr>
@@ -68,12 +69,16 @@ while($d<=$daysInMonth){
     echo '<td><a href="record.php?service_date='.$linkDate.'"><strong>'.$d.'</strong></a><br>';
     if(isset($records[$d])){
         foreach($records[$d] as $rec){
-            echo '<a href="record.php?id='.$rec['id'].'">'.htmlspecialchars($rec['license']).'</a><br>';
+            $lic = htmlspecialchars($rec['license']);
+            $disp = '<strong>'.mb_substr($lic,0,8,'UTF-8').'</strong>'.mb_substr($lic,8,null,'UTF-8');
+            echo '<a href="record.php?id='.$rec['id'].'">'.$disp.'</a><br>';
         }
     }
     if(isset($services[$d])){
         foreach($services[$d] as $rec){
-            echo '<span style="color:green;font-weight:bold;">'.htmlspecialchars($rec['license']).'</span><br>';
+            $lic = htmlspecialchars($rec['license']);
+            $disp = '<strong>'.mb_substr($lic,0,8,'UTF-8').'</strong>'.mb_substr($lic,8,null,'UTF-8');
+            echo '<span style="color:green;font-weight:bold;">'.$disp.'</span><br>';
         }
     }
     echo '</td>';

--- a/www.technology.gr/coder/calendar.php
+++ b/www.technology.gr/coder/calendar.php
@@ -9,12 +9,16 @@ $firstDay = mktime(0,0,0,$month,1,$year);
 $daysInMonth = date('t',$firstDay);
 $months_gr = ['', 'Ιανουάριος','Φεβρουάριος','Μάρτιος','Απρίλιος','Μάιος','Ιούνιος','Ιούλιος','Αύγουστος','Σεπτέμβριος','Οκτώβριος','Νοέμβριος','Δεκέμβριος'];
 
-$stmt = $pdo->prepare('SELECT id,movement_date,license FROM car_jobs WHERE MONTH(movement_date)=? AND YEAR(movement_date)=?');
-$stmt->execute([$month,$year]);
-$records = [];
+$stmt = $pdo->prepare('SELECT id,movement_date,next_service_date,license FROM car_jobs WHERE (MONTH(movement_date)=? AND YEAR(movement_date)=?) OR (next_service_date IS NOT NULL AND MONTH(next_service_date)=? AND YEAR(next_service_date)=?)');
+$stmt->execute([$month,$year,$month,$year]);
+$records = $services = [];
 while($r=$stmt->fetch()){
-    $day = (int)date('j',strtotime($r['movement_date']));
-    $records[$day][] = $r;
+    $dayMove = (int)date('j',strtotime($r['movement_date']));
+    $records[$dayMove][] = ['id'=>$r['id'],'license'=>$r['license']];
+    if($r['next_service_date']){
+        $dayServ = (int)date('j',strtotime($r['next_service_date']));
+        $services[$dayServ][] = ['id'=>$r['id'],'license'=>$r['license']];
+    }
 }
 $prevMonth = $month-1;$prevYear=$year;if($prevMonth<1){$prevMonth=12;$prevYear--;}
 $nextMonth = $month+1;$nextYear=$year;if($nextMonth>12){$nextMonth=1;$nextYear++;}
@@ -26,7 +30,8 @@ $nextMonth = $month+1;$nextYear=$year;if($nextMonth>12){$nextMonth=1;$nextYear++
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Ημερολόγιο</title>
 <style>
-body{font-family:Arial,sans-serif;margin:0;padding:0;}
+body{font-family:Arial,sans-serif;margin:0;padding:0;display:flex;min-height:100vh;flex-direction:column;}
+main{flex:1;}
 header{padding:1em;background:#333;color:#fff;text-align:center;}
 footer{padding:.3em;background:#333;color:#fff;font-size:12px;text-align:left;}
 table{border-collapse:collapse;width:100%;}
@@ -46,6 +51,7 @@ nav a{margin-right:10px;}
         <a href="helpers.php" style="color:#fff;">Βοηθητικά</a>
     </nav>
 </header>
+<main>
 <h2 style="text-align:center;"><?= mb_strtoupper($months_gr[$month], 'UTF-8').' '. $year ?></h2>
 <div style="text-align:center;margin-bottom:1em;">
 <a href="?month=<?=$prevMonth?>&year=<?=$prevYear?>">&laquo;</a>
@@ -64,12 +70,18 @@ while($d<=$daysInMonth){
             echo '<a href="record.php?id='.$rec['id'].'">'.htmlspecialchars($rec['license']).'</a><br>';
         }
     }
+    if(isset($services[$d])){
+        foreach($services[$d] as $rec){
+            echo '<span style="color:green;font-weight:bold;">'.htmlspecialchars($rec['license']).'</span><br>';
+        }
+    }
     echo '</td>';
     $d++;$i++;}
 for(;$i<=7;$i++)echo '<td></td>';
 ?>
 </tr>
 </table>
+</main>
 <footer>ver 1.0  (c) 2025</footer>
 </body>
 </html>

--- a/www.technology.gr/coder/calendar.php
+++ b/www.technology.gr/coder/calendar.php
@@ -7,6 +7,7 @@ $month = isset($_GET['month']) ? intval($_GET['month']) : date('n');
 $year  = isset($_GET['year']) ? intval($_GET['year']) : date('Y');
 $firstDay = mktime(0,0,0,$month,1,$year);
 $daysInMonth = date('t',$firstDay);
+$months_gr = ['', 'Ιανουάριος','Φεβρουάριος','Μάρτιος','Απρίλιος','Μάιος','Ιούνιος','Ιούλιος','Αύγουστος','Σεπτέμβριος','Οκτώβριος','Νοέμβριος','Δεκέμβριος'];
 
 $stmt = $pdo->prepare('SELECT id,movement_date,license FROM car_jobs WHERE MONTH(movement_date)=? AND YEAR(movement_date)=?');
 $stmt->execute([$month,$year]);
@@ -25,17 +26,27 @@ $nextMonth = $month+1;$nextYear=$year;if($nextMonth>12){$nextMonth=1;$nextYear++
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Ημερολόγιο</title>
 <style>
-body{font-family:Arial,sans-serif;margin:0;padding:1em;}
+body{font-family:Arial,sans-serif;margin:0;padding:0;}
+header{padding:1em;background:#333;color:#fff;text-align:center;}
+footer{padding:.3em;background:#333;color:#fff;font-size:12px;text-align:left;}
 table{border-collapse:collapse;width:100%;}
-th,td{border:1px solid #ccc;padding:5px;height:80px;vertical-align:top;}
+th,td{border:1px solid #ccc;padding:5px;height:80px;vertical-align:top;width:14.28%;}
 th{background:#f0f0f0;}
 @media(max-width:600px){th,td{height:auto;font-size:12px;}}
 nav a{margin-right:10px;}
 </style>
 </head>
 <body>
-<nav><a href="index.php">Αρχική</a></nav>
-<h2 style="text-align:center;"><?= sprintf('%02d/%04d',$month,$year) ?></h2>
+<header>
+    <h1>Εργασίες Οχημάτων</h1>
+    <nav>
+        <a href="index.php" style="color:#fff;margin-right:10px;">Αρχική</a>
+        <a href="record.php" style="color:#fff;margin-right:10px;">Νέα Καταχώρηση</a>
+        <a href="calendar.php" style="color:#fff;margin-right:10px;">Ημερολόγιο</a>
+        <a href="helpers.php" style="color:#fff;">Βοηθητικά</a>
+    </nav>
+</header>
+<h2 style="text-align:center;"><?= mb_strtoupper($months_gr[$month], 'UTF-8').' '. $year ?></h2>
 <div style="text-align:center;margin-bottom:1em;">
 <a href="?month=<?=$prevMonth?>&year=<?=$prevYear?>">&laquo;</a>
 <a href="?month=<?=$nextMonth?>&year=<?=$nextYear?>">&raquo;</a>
@@ -59,5 +70,6 @@ for(;$i<=7;$i++)echo '<td></td>';
 ?>
 </tr>
 </table>
+<footer>ver 1.0  (c) 2025</footer>
 </body>
 </html>

--- a/www.technology.gr/coder/calendar.php
+++ b/www.technology.gr/coder/calendar.php
@@ -1,0 +1,63 @@
+<?php
+require 'config.php';
+session_start();
+if(!isset($_SESSION['logged_in'])){header('Location: index.php');exit();}
+
+$month = isset($_GET['month']) ? intval($_GET['month']) : date('n');
+$year  = isset($_GET['year']) ? intval($_GET['year']) : date('Y');
+$firstDay = mktime(0,0,0,$month,1,$year);
+$daysInMonth = date('t',$firstDay);
+
+$stmt = $pdo->prepare('SELECT id,movement_date,license FROM car_jobs WHERE MONTH(movement_date)=? AND YEAR(movement_date)=?');
+$stmt->execute([$month,$year]);
+$records = [];
+while($r=$stmt->fetch()){
+    $day = (int)date('j',strtotime($r['movement_date']));
+    $records[$day][] = $r;
+}
+$prevMonth = $month-1;$prevYear=$year;if($prevMonth<1){$prevMonth=12;$prevYear--;}
+$nextMonth = $month+1;$nextYear=$year;if($nextMonth>12){$nextMonth=1;$nextYear++;}
+?>
+<!DOCTYPE html>
+<html lang="el">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Ημερολόγιο</title>
+<style>
+body{font-family:Arial,sans-serif;margin:0;padding:1em;}
+table{border-collapse:collapse;width:100%;}
+th,td{border:1px solid #ccc;padding:5px;height:80px;vertical-align:top;}
+th{background:#f0f0f0;}
+@media(max-width:600px){th,td{height:auto;font-size:12px;}}
+nav a{margin-right:10px;}
+</style>
+</head>
+<body>
+<nav><a href="index.php">Αρχική</a></nav>
+<h2 style="text-align:center;"><?= sprintf('%02d/%04d',$month,$year) ?></h2>
+<div style="text-align:center;margin-bottom:1em;">
+<a href="?month=<?=$prevMonth?>&year=<?=$prevYear?>">&laquo;</a>
+<a href="?month=<?=$nextMonth?>&year=<?=$nextYear?>">&raquo;</a>
+</div>
+<table>
+<tr><th>Δευ</th><th>Τρι</th><th>Τετ</th><th>Πεμ</th><th>Παρ</th><th>Σαβ</th><th>Κυρ</th></tr>
+<?php
+$dayOfWeek=date('N',$firstDay);echo '<tr>';for($i=1;$i<$dayOfWeek;$i++)echo '<td></td>';
+$d=1;$i=$dayOfWeek;
+while($d<=$daysInMonth){
+    if($i==8){echo '</tr><tr>';$i=1;}
+    echo '<td><strong>'.$d.'</strong><br>';
+    if(isset($records[$d])){
+        foreach($records[$d] as $rec){
+            echo '<a href="record.php?id='.$rec['id'].'">'.htmlspecialchars($rec['license']).'</a><br>';
+        }
+    }
+    echo '</td>';
+    $d++;$i++;}
+for(;$i<=7;$i++)echo '<td></td>';
+?>
+</tr>
+</table>
+</body>
+</html>

--- a/www.technology.gr/coder/calendar.php
+++ b/www.technology.gr/coder/calendar.php
@@ -64,7 +64,8 @@ $dayOfWeek=date('N',$firstDay);echo '<tr>';for($i=1;$i<$dayOfWeek;$i++)echo '<td
 $d=1;$i=$dayOfWeek;
 while($d<=$daysInMonth){
     if($i==8){echo '</tr><tr>';$i=1;}
-    echo '<td><strong>'.$d.'</strong><br>';
+    $linkDate = sprintf('%04d-%02d-%02d',$year,$month,$d);
+    echo '<td><a href="record.php?service_date='.$linkDate.'"><strong>'.$d.'</strong></a><br>';
     if(isset($records[$d])){
         foreach($records[$d] as $rec){
             echo '<a href="record.php?id='.$rec['id'].'">'.htmlspecialchars($rec['license']).'</a><br>';

--- a/www.technology.gr/coder/calendar.php
+++ b/www.technology.gr/coder/calendar.php
@@ -28,6 +28,7 @@ $nextMonth = $month+1;$nextYear=$year;if($nextMonth>12){$nextMonth=1;$nextYear++
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex, nofollow">
 <title>Ημερολόγιο</title>
 <style>
 body{font-family:Arial,sans-serif;margin:0;padding:0;display:flex;min-height:100vh;flex-direction:column;}
@@ -36,7 +37,8 @@ header{padding:1em;background:#333;color:#fff;text-align:center;}
 footer{padding:.3em;background:#333;color:#fff;font-size:12px;text-align:left;}
 table{border-collapse:collapse;width:100%;}
 th,td{border:1px solid #ccc;padding:5px;height:80px;vertical-align:top;width:14.28%;}
-td strong{font-size:14px;}
+td strong{font-size:28px;color:#000;}
+td a{color:#000;text-decoration:none;}
 th{background:#f0f0f0;}
 @media(max-width:600px){th,td{height:auto;font-size:12px;}}
 nav a{margin-right:10px;}

--- a/www.technology.gr/coder/config.php
+++ b/www.technology.gr/coder/config.php
@@ -1,0 +1,18 @@
+<?php
+$host = 'localhost';
+$db   = 'coder_bash';
+$user = 'coder_user';
+$pass = 't$3f3a@xxy413500';
+$charset = 'utf8mb4';
+$dsn = "mysql:host=$host;dbname=$db;charset=$charset";
+$options = [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES   => false,
+];
+try {
+    $pdo = new PDO($dsn, $user, $pass, $options);
+} catch (PDOException $e) {
+    exit('Database connection failed: ' . $e->getMessage());
+}
+?>

--- a/www.technology.gr/coder/export.php
+++ b/www.technology.gr/coder/export.php
@@ -12,7 +12,7 @@ function fmt_date($d){
 }
 
 // optional filters
-$sql = 'SELECT movement_date, license, kilometers, employee, workplace, work_type, description, id FROM car_jobs WHERE 1';
+$sql = 'SELECT movement_date, license, kilometers, employee, workplace, work_type, description, next_service_date, next_service_km, user_notes, battery, tires, id FROM car_jobs WHERE 1';
 $params = [];
 if(isset($_GET['f_date']) && $_GET['f_date']){ $sql .= ' AND movement_date=?'; $params[] = $_GET['f_date']; }
 if(isset($_GET['f_license']) && $_GET['f_license']){ $sql .= ' AND license=?'; $params[] = $_GET['f_license']; }
@@ -29,7 +29,7 @@ if($type === 'excel'){
     echo "\xEF\xBB\xBF"; // UTF-8 BOM
     echo "<html><head><meta charset=\"UTF-8\"><style>table{border-collapse:collapse;}td,th{border:1px solid #000;padding:4px;font-family:Arial,Helvetica,sans-serif;}</style></head><body>";
     echo "<table>";
-    echo "<tr><th>Ημερομηνία</th><th>Πινακίδα</th><th>Χιλιόμετρα</th><th>Υπάλληλος</th><th>Τόπος</th><th>Είδος</th><th>Περιγραφή</th></tr>";
+    echo "<tr><th>Ημερομηνία</th><th>Πινακίδα</th><th>Χιλιόμετρα</th><th>Υπάλληλος</th><th>Τόπος</th><th>Είδος</th><th>Περιγραφή</th><th>Επόμ. Serv Ημ.</th><th>Επόμ. Serv Χλμ</th><th>Σημειώσεις</th><th>Μπαταρία</th><th>Ελαστικά</th></tr>";
     foreach($records as $r){
         echo '<tr>';
         echo '<td>'.fmt_date($r['movement_date']).'</td>';
@@ -39,6 +39,11 @@ if($type === 'excel'){
         echo '<td>'.htmlspecialchars($r['workplace']).'</td>';
         echo '<td>'.htmlspecialchars($r['work_type']).'</td>';
         echo '<td>'.nl2br(htmlspecialchars($r['description'])).'</td>';
+        echo '<td>'.($r['next_service_date']?fmt_date($r['next_service_date']):'').'</td>';
+        echo '<td>'.($r['next_service_km']?number_format($r['next_service_km'],0,',','.'):'' ).'</td>';
+        echo '<td>'.nl2br(htmlspecialchars($r['user_notes'])).'</td>';
+        echo '<td>'.htmlspecialchars($r['battery']).'</td>';
+        echo '<td>'.htmlspecialchars($r['tires']).'</td>';
         echo '</tr>';
     }
     echo "</table></body></html>";
@@ -49,7 +54,7 @@ $width = 842; // landscape A4
 $height = 595;
 $margin = 20;
 $rowHeight = 20;
-$columns = ['Ημερομηνία','Πινακίδα','Χιλιόμετρα','Υπάλληλος','Τόπος','Είδος','Περιγραφή'];
+$columns = ['Ημερομηνία','Πινακίδα','Χιλιόμετρα','Υπάλληλος','Τόπος','Είδος','Περιγραφή','Επόμ. Serv Ημ.','Επόμ. Serv Χλμ','Σημειώσεις','Μπαταρία','Ελαστικά'];
 $colCount = count($columns);
 $usableWidth = $width - $margin*2;
 $colWidth = $usableWidth / $colCount;
@@ -68,7 +73,12 @@ foreach($records as $r){
         $r['employee'],
         $r['workplace'],
         $r['work_type'],
-        str_replace(["\n","\r"], ' ', $r['description'])
+        str_replace(["\n","\r"], ' ', $r['description']),
+        $r['next_service_date']?fmt_date($r['next_service_date']):'',
+        $r['next_service_km']?number_format($r['next_service_km'],0,',','.'):'',
+        str_replace(["\n","\r"], ' ', $r['user_notes']),
+        $r['battery'],
+        $r['tires']
     ];
 }
 

--- a/www.technology.gr/coder/export.php
+++ b/www.technology.gr/coder/export.php
@@ -14,10 +14,20 @@ function fmt_date($d){
 // optional filters
 $sql = 'SELECT movement_date, license, kilometers, employee, workplace, work_type, description, next_service_date, next_service_km, user_notes, battery, tires, id FROM car_jobs WHERE 1';
 $params = [];
-if(isset($_GET['f_date']) && $_GET['f_date']){ $sql .= ' AND movement_date=?'; $params[] = $_GET['f_date']; }
-if(isset($_GET['f_license']) && $_GET['f_license']){ $sql .= ' AND license=?'; $params[] = $_GET['f_license']; }
-if(isset($_GET['f_workplace']) && $_GET['f_workplace']){ $sql .= ' AND workplace=?'; $params[] = $_GET['f_workplace']; }
-if(isset($_GET['f_work_type']) && $_GET['f_work_type']){ $sql .= ' AND work_type=?'; $params[] = $_GET['f_work_type']; }
+$filterKeys = [
+    'f_date' => 'movement_date',
+    'f_license' => 'license',
+    'f_workplace' => 'workplace',
+    'f_work_type' => 'work_type',
+    'f_battery' => 'battery',
+    'f_tires' => 'tires'
+];
+foreach($filterKeys as $param => $col){
+    if(isset($_GET[$param]) && $_GET[$param] !== ''){
+        $sql .= " AND $col=?";
+        $params[] = $_GET[$param];
+    }
+}
 $sql .= ' ORDER BY movement_date DESC, id DESC';
 $stmt = $pdo->prepare($sql);
 $stmt->execute($params);

--- a/www.technology.gr/coder/export.php
+++ b/www.technology.gr/coder/export.php
@@ -7,7 +7,20 @@ if(!isset($_SESSION['logged_in'])){
 }
 $type = isset($_GET['type']) ? $_GET['type'] : 'excel';
 
-$stmt = $pdo->query('SELECT movement_date, license, kilometers, employee, workplace, work_type, description FROM car_jobs ORDER BY movement_date DESC, id DESC');
+function fmt_date($d){
+    return date('d-m-Y', strtotime($d));
+}
+
+// optional filters
+$sql = 'SELECT movement_date, license, kilometers, employee, workplace, work_type, description, id FROM car_jobs WHERE 1';
+$params = [];
+if(isset($_GET['f_date']) && $_GET['f_date']){ $sql .= ' AND movement_date=?'; $params[] = $_GET['f_date']; }
+if(isset($_GET['f_license']) && $_GET['f_license']){ $sql .= ' AND license=?'; $params[] = $_GET['f_license']; }
+if(isset($_GET['f_workplace']) && $_GET['f_workplace']){ $sql .= ' AND workplace=?'; $params[] = $_GET['f_workplace']; }
+if(isset($_GET['f_work_type']) && $_GET['f_work_type']){ $sql .= ' AND work_type=?'; $params[] = $_GET['f_work_type']; }
+$sql .= ' ORDER BY movement_date DESC, id DESC';
+$stmt = $pdo->prepare($sql);
+$stmt->execute($params);
 $records = $stmt->fetchAll();
 
 if($type === 'excel'){
@@ -19,9 +32,9 @@ if($type === 'excel'){
     echo "<tr><th>Ημερομηνία</th><th>Πινακίδα</th><th>Χιλιόμετρα</th><th>Υπάλληλος</th><th>Τόπος</th><th>Είδος</th><th>Περιγραφή</th></tr>";
     foreach($records as $r){
         echo '<tr>';
-        echo '<td>'.htmlspecialchars($r['movement_date']).'</td>';
+        echo '<td>'.fmt_date($r['movement_date']).'</td>';
         echo '<td>'.htmlspecialchars($r['license']).'</td>';
-        echo '<td>'.htmlspecialchars($r['kilometers']).'</td>';
+        echo '<td>'.number_format($r['kilometers'],0,',','.') .'</td>';
         echo '<td>'.htmlspecialchars($r['employee']).'</td>';
         echo '<td>'.htmlspecialchars($r['workplace']).'</td>';
         echo '<td>'.htmlspecialchars($r['work_type']).'</td>';
@@ -49,9 +62,9 @@ $rows = [];
 $rows[] = $columns;
 foreach($records as $r){
     $rows[] = [
-        $r['movement_date'],
+        fmt_date($r['movement_date']),
         $r['license'],
-        $r['kilometers'],
+        number_format($r['kilometers'],0,',','.'),
         $r['employee'],
         $r['workplace'],
         $r['work_type'],

--- a/www.technology.gr/coder/export.php
+++ b/www.technology.gr/coder/export.php
@@ -1,0 +1,102 @@
+<?php
+require 'config.php';
+session_start();
+if(!isset($_SESSION['logged_in'])){
+    header('Location: index.php');
+    exit();
+}
+$type = isset($_GET['type']) ? $_GET['type'] : 'excel';
+
+$stmt = $pdo->query('SELECT movement_date, license, kilometers, employee, workplace, work_type, description FROM car_jobs ORDER BY movement_date DESC, id DESC');
+$records = $stmt->fetchAll();
+
+if($type === 'excel'){
+    header('Content-Type: application/vnd.ms-excel; charset=UTF-8');
+    header('Content-Disposition: attachment; filename="records.xls"');
+    echo "\xEF\xBB\xBF"; // UTF-8 BOM
+    echo "<html><head><meta charset=\"UTF-8\"><style>table{border-collapse:collapse;}td,th{border:1px solid #000;padding:4px;font-family:Arial,Helvetica,sans-serif;}</style></head><body>";
+    echo "<table>";
+    echo "<tr><th>Ημερομηνία</th><th>Πινακίδα</th><th>Χιλιόμετρα</th><th>Υπάλληλος</th><th>Τόπος</th><th>Είδος</th><th>Περιγραφή</th></tr>";
+    foreach($records as $r){
+        echo '<tr>';
+        echo '<td>'.htmlspecialchars($r['movement_date']).'</td>';
+        echo '<td>'.htmlspecialchars($r['license']).'</td>';
+        echo '<td>'.htmlspecialchars($r['kilometers']).'</td>';
+        echo '<td>'.htmlspecialchars($r['employee']).'</td>';
+        echo '<td>'.htmlspecialchars($r['workplace']).'</td>';
+        echo '<td>'.htmlspecialchars($r['work_type']).'</td>';
+        echo '<td>'.nl2br(htmlspecialchars($r['description'])).'</td>';
+        echo '</tr>';
+    }
+    echo "</table></body></html>";
+    exit();
+}
+
+$width = 842; // landscape A4
+$height = 595;
+$margin = 20;
+$rowHeight = 20;
+$columns = ['Ημερομηνία','Πινακίδα','Χιλιόμετρα','Υπάλληλος','Τόπος','Είδος','Περιγραφή'];
+$colCount = count($columns);
+$usableWidth = $width - $margin*2;
+$colWidth = $usableWidth / $colCount;
+
+function pdf_escape($str){
+    return str_replace(['\\', '(', ')'], ['\\\\', '\\(', '\\)'], $str);
+}
+
+$rows = [];
+$rows[] = $columns;
+foreach($records as $r){
+    $rows[] = [
+        $r['movement_date'],
+        $r['license'],
+        $r['kilometers'],
+        $r['employee'],
+        $r['workplace'],
+        $r['work_type'],
+        str_replace(["\n","\r"], ' ', $r['description'])
+    ];
+}
+
+$content = "";
+$y = $height - $margin - $rowHeight;
+
+foreach($rows as $row){
+    $x = $margin;
+    for($i=0;$i<$colCount;$i++){
+        $text = pdf_escape($row[$i]);
+        $content .= "$x $y $colWidth $rowHeight re S\n"; // cell border
+        $content .= "BT /F1 10 Tf ".($x+2)." ".($y+5)." Td (".$text.") Tj ET\n";
+        $x += $colWidth;
+    }
+    $y -= $rowHeight;
+}
+
+$len = strlen($content);
+$objects = [];
+$objects[] = "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n";
+$objects[] = "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n";
+$objects[] = "3 0 obj\n<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 4 0 R >> >> /MediaBox [0 0 $width $height] /Contents 5 0 R >>\nendobj\n";
+$objects[] = "4 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n";
+$objects[] = "5 0 obj\n<< /Length $len >>\nstream\n$content\nendstream\nendobj\n";
+
+$out = "%PDF-1.3\n";
+$offsets = [];
+foreach($objects as $obj){
+    $offsets[] = strlen($out);
+    $out .= $obj;
+}
+$xref = strlen($out);
+$out .= "xref\n0 ".(count($objects)+1)."\n0000000000 65535 f \n";
+for($i=0;$i<count($offsets);$i++){
+    $out .= sprintf("%010d 00000 n \n", $offsets[$i]);
+}
+$out .= "trailer\n<< /Size ".(count($objects)+1)." /Root 1 0 R >>\nstartxref\n$xref\n%%EOF";
+
+header('Content-Type: application/pdf');
+header('Content-Disposition: attachment; filename="records.pdf"');
+header('Content-Length: '.strlen($out));
+
+echo $out;
+?>

--- a/www.technology.gr/coder/export.php
+++ b/www.technology.gr/coder/export.php
@@ -39,7 +39,7 @@ if($type === 'excel'){
     echo "\xEF\xBB\xBF"; // UTF-8 BOM
     echo "<html><head><meta charset=\"UTF-8\"><style>table{border-collapse:collapse;}td,th{border:1px solid #000;padding:4px;font-family:Arial,Helvetica,sans-serif;}</style></head><body>";
     echo "<table>";
-    echo "<tr><th>Ημερομηνία</th><th>Πινακίδα</th><th>Χιλιόμετρα</th><th>Υπάλληλος</th><th>Τόπος</th><th>Είδος</th><th>Περιγραφή</th><th>Επόμ. Serv Ημ.</th><th>Επόμ. Serv Χλμ</th><th>Σημειώσεις</th><th>Μπαταρία</th><th>Ελαστικά</th></tr>";
+    echo "<tr><th>Ημερομηνία εγγραφής</th><th>Οχημα</th><th>Χιλιόμετρα</th><th>Υπάλληλος</th><th>Τόπος</th><th>Είδος</th><th>Περιγραφή</th><th>Ημ/νία Επόμ. Service</th><th>ΧΛΜ Επόμ. Service</th><th>Σημειώσεις</th><th>Αφορά Μπαταρία</th><th>Αφορά Ελαστικά</th></tr>";
     foreach($records as $r){
         echo '<tr>';
         echo '<td>'.fmt_date($r['movement_date']).'</td>';
@@ -64,7 +64,7 @@ $width = 842; // landscape A4
 $height = 595;
 $margin = 20;
 $rowHeight = 20;
-$columns = ['Ημερομηνία','Πινακίδα','Χιλιόμετρα','Υπάλληλος','Τόπος','Είδος','Περιγραφή','Επόμ. Serv Ημ.','Επόμ. Serv Χλμ','Σημειώσεις','Μπαταρία','Ελαστικά'];
+$columns = ['Ημερομηνία εγγραφής','Οχημα','Χιλιόμετρα','Υπάλληλος','Τόπος','Είδος','Περιγραφή','Ημ/νία Επόμ. Service','ΧΛΜ Επόμ. Service','Σημειώσεις','Αφορά Μπαταρία','Αφορά Ελαστικά'];
 $colCount = count($columns);
 $usableWidth = $width - $margin*2;
 $colWidth = $usableWidth / $colCount;

--- a/www.technology.gr/coder/helpers.php
+++ b/www.technology.gr/coder/helpers.php
@@ -12,7 +12,9 @@ if (!isset($_SESSION['logged_in'])) {
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Βοηθητικά</title>
 <style>
-    body{font-family:Arial,sans-serif;margin:0;padding:1em;background:#f4f4f4;}
+    body{font-family:Arial,sans-serif;margin:0;padding:0;background:#f4f4f4;}
+    header{padding:1em;background:#333;color:#fff;text-align:center;}
+    footer{padding:.3em;background:#333;color:#fff;font-size:12px;text-align:left;}
     h1{text-align:center;}
     ul{list-style:none;padding:0;max-width:300px;margin:0 auto;}
     li{margin:0.5em 0;}
@@ -20,6 +22,15 @@ if (!isset($_SESSION['logged_in'])) {
 </style>
 </head>
 <body>
+<header>
+    <h1>Εργασίες Οχημάτων</h1>
+    <nav>
+        <a href="index.php" style="color:#fff;margin-right:10px;">Αρχική</a>
+        <a href="record.php" style="color:#fff;margin-right:10px;">Νέα Καταχώρηση</a>
+        <a href="calendar.php" style="color:#fff;margin-right:10px;">Ημερολόγιο</a>
+        <a href="helpers.php" style="color:#fff;">Βοηθητικά</a>
+    </nav>
+</header>
 <h1>Βοηθητικές Λίστες</h1>
 <ul>
     <li><a href="manage.php?entity=licenses">Πινακίδες Οχημάτων</a></li>
@@ -27,5 +38,6 @@ if (!isset($_SESSION['logged_in'])) {
     <li><a href="manage.php?entity=workplaces">Τόποι Εργασίας</a></li>
 </ul>
 <p style="text-align:center;"><a href="index.php" style="background:#ccc;color:#000;">Επιστροφή</a></p>
+<footer>ver 1.0  (c) 2025</footer>
 </body>
 </html>

--- a/www.technology.gr/coder/helpers.php
+++ b/www.technology.gr/coder/helpers.php
@@ -1,0 +1,31 @@
+<?php
+session_start();
+if (!isset($_SESSION['logged_in'])) {
+    header('Location: index.php');
+    exit();
+}
+?>
+<!DOCTYPE html>
+<html lang="el">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Βοηθητικά</title>
+<style>
+    body{font-family:Arial,sans-serif;margin:0;padding:1em;background:#f4f4f4;}
+    h1{text-align:center;}
+    ul{list-style:none;padding:0;max-width:300px;margin:0 auto;}
+    li{margin:0.5em 0;}
+    a{display:block;padding:0.5em;background:#007bff;color:#fff;text-decoration:none;border-radius:4px;text-align:center;}
+</style>
+</head>
+<body>
+<h1>Βοηθητικές Λίστες</h1>
+<ul>
+    <li><a href="manage.php?entity=licenses">Πινακίδες Οχημάτων</a></li>
+    <li><a href="manage.php?entity=employees">Υπάλληλοι</a></li>
+    <li><a href="manage.php?entity=workplaces">Τόποι Εργασίας</a></li>
+</ul>
+<p style="text-align:center;"><a href="index.php" style="background:#ccc;color:#000;">Επιστροφή</a></p>
+</body>
+</html>

--- a/www.technology.gr/coder/helpers.php
+++ b/www.technology.gr/coder/helpers.php
@@ -18,7 +18,8 @@ if (!isset($_SESSION['logged_in'])) {
     h1{text-align:center;}
     ul{list-style:none;padding:0;max-width:300px;margin:0 auto;}
     li{margin:0.5em 0;}
-    a{display:block;padding:0.5em;background:#333;color:#fff;text-decoration:none;border-radius:4px;text-align:center;}
+    ul li a{display:block;padding:0.5em;background:#007bff;color:#fff;text-decoration:none;border-radius:4px;text-align:center;}
+    header nav a{display:inline-block;margin-right:10px;color:#fff;text-decoration:none;background:none;padding:0;}
 </style>
 </head>
 <body>

--- a/www.technology.gr/coder/helpers.php
+++ b/www.technology.gr/coder/helpers.php
@@ -27,7 +27,7 @@ if (!isset($_SESSION['logged_in'])) {
     <h1>Εργασίες Οχημάτων</h1>
     <nav>
         <a href="index.php" style="color:#fff;margin-right:10px;">Αρχική</a>
-        <a href="record.php" style="color:#fff;margin-right:10px;">Νέα Καταχώρηση</a>
+        <a href="record.php" style="color:#fff;margin-right:10px;">Νέα Καταχώριση</a>
         <a href="calendar.php" style="color:#fff;margin-right:10px;">Ημερολόγιο</a>
         <a href="helpers.php" style="color:#fff;">Βοηθητικά</a>
     </nav>

--- a/www.technology.gr/coder/helpers.php
+++ b/www.technology.gr/coder/helpers.php
@@ -18,7 +18,7 @@ if (!isset($_SESSION['logged_in'])) {
     h1{text-align:center;}
     ul{list-style:none;padding:0;max-width:300px;margin:0 auto;}
     li{margin:0.5em 0;}
-    a{display:block;padding:0.5em;background:#007bff;color:#fff;text-decoration:none;border-radius:4px;text-align:center;}
+    a{display:block;padding:0.5em;background:#333;color:#fff;text-decoration:none;border-radius:4px;text-align:center;}
 </style>
 </head>
 <body>

--- a/www.technology.gr/coder/helpers.php
+++ b/www.technology.gr/coder/helpers.php
@@ -10,6 +10,7 @@ if (!isset($_SESSION['logged_in'])) {
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex, nofollow">
 <title>Βοηθητικά</title>
 <style>
     body{font-family:Arial,sans-serif;margin:0;padding:0;background:#f4f4f4;}
@@ -37,6 +38,7 @@ if (!isset($_SESSION['logged_in'])) {
     <li><a href="manage.php?entity=licenses">Πινακίδες Οχημάτων</a></li>
     <li><a href="manage.php?entity=employees">Υπάλληλοι</a></li>
     <li><a href="manage.php?entity=workplaces">Τόποι Εργασίας</a></li>
+    <li><a href="manage.php?entity=work_types">Είδη Εργασίας</a></li>
 </ul>
 <p style="text-align:center;"><a href="index.php" style="background:#ccc;color:#000;">Επιστροφή</a></p>
 <footer>ver 1.0  (c) 2025</footer>

--- a/www.technology.gr/coder/index.php
+++ b/www.technology.gr/coder/index.php
@@ -52,8 +52,29 @@ if (isset($_GET['delete'])) {
     exit();
 }
 
-// Fetch all records
-$stmt = $pdo->query('SELECT * FROM car_jobs ORDER BY movement_date DESC, id DESC');
+function fmt_date($d){
+    return date('d-m-Y', strtotime($d));
+}
+
+// fetch dropdown lists for filters
+$licenses = $pdo->query("SELECT name FROM licenses ORDER BY name")->fetchAll(PDO::FETCH_COLUMN);
+$workplaces = $pdo->query("SELECT name FROM workplaces ORDER BY name")->fetchAll(PDO::FETCH_COLUMN);
+$work_types = ["Εκτακτη βλάβη","Προγραμματισμένο Service","Προγραμματισμένος έλεγχος","Αλλο γεγονός"];
+
+// Build filtering query
+$sql = 'SELECT * FROM car_jobs WHERE 1';
+$params = [];
+$filter_date = $_GET['f_date'] ?? '';
+$filter_license = $_GET['f_license'] ?? '';
+$filter_workplace = $_GET['f_workplace'] ?? '';
+$filter_work_type = $_GET['f_work_type'] ?? '';
+if($filter_date){ $sql .= ' AND movement_date = ?'; $params[] = $filter_date; }
+if($filter_license){ $sql .= ' AND license = ?'; $params[] = $filter_license; }
+if($filter_workplace){ $sql .= ' AND workplace = ?'; $params[] = $filter_workplace; }
+if($filter_work_type){ $sql .= ' AND work_type = ?'; $params[] = $filter_work_type; }
+$sql .= ' ORDER BY movement_date DESC, id DESC';
+$stmt = $pdo->prepare($sql);
+$stmt->execute($params);
 $records = $stmt->fetchAll();
 ?>
 <!DOCTYPE html>
@@ -83,28 +104,61 @@ $records = $stmt->fetchAll();
 <nav>
     <a href="index.php" style="color:#fff;margin-right:10px;">Αρχική</a>
     <a href="record.php" style="color:#fff;margin-right:10px;">Νέα Καταχώρηση</a>
+    <a href="calendar.php" style="color:#fff;margin-right:10px;">Ημερολόγιο</a>
     <a href="helpers.php" style="color:#fff;">Βοηθητικά</a>
 </nav>
 </header>
 <div class="container">
 <p><a href="record.php">Νέα Καταχώρηση</a></p>
 <div style="overflow-x:auto;">
+<form method="get">
 <table>
 <tr>
-    <th>Ημερομηνία</th>
-    <th>Πινακίδα</th>
+    <th>Ημερομηνία<br>🔍</th>
+    <th>Πινακίδα<br>🔍</th>
     <th>Χιλιόμετρα</th>
     <th>Υπάλληλος</th>
-    <th>Τόπος</th>
-    <th>Είδος</th>
+    <th>Τόπος<br>🔍</th>
+    <th>Είδος<br>🔍</th>
     <th>Περιγραφή</th>
     <th>Ενέργειες</th>
 </tr>
+<tr>
+    <td><input type="date" name="f_date" value="<?= htmlspecialchars($filter_date) ?>" style="width:100%;"></td>
+    <td>
+        <select name="f_license" style="width:100%;">
+            <option value="">--</option>
+            <?php foreach($licenses as $opt): ?>
+            <option value="<?= $opt ?>" <?= $filter_license==$opt?'selected':'' ?>><?= $opt ?></option>
+            <?php endforeach; ?>
+        </select>
+    </td>
+    <td></td>
+    <td></td>
+    <td>
+        <select name="f_workplace" style="width:100%;">
+            <option value="">--</option>
+            <?php foreach($workplaces as $opt): ?>
+            <option value="<?= $opt ?>" <?= $filter_workplace==$opt?'selected':'' ?>><?= $opt ?></option>
+            <?php endforeach; ?>
+        </select>
+    </td>
+    <td>
+        <select name="f_work_type" style="width:100%;">
+            <option value="">--</option>
+            <?php foreach($work_types as $opt): ?>
+            <option value="<?= $opt ?>" <?= $filter_work_type==$opt?'selected':'' ?>><?= $opt ?></option>
+            <?php endforeach; ?>
+        </select>
+    </td>
+    <td></td>
+    <td><button type="submit">OK</button> <a href="index.php">Reset</a></td>
+</tr>
 <?php foreach ($records as $row): ?>
 <tr>
-    <td data-label="Ημερομηνία"><?= htmlspecialchars($row['movement_date']) ?></td>
+    <td data-label="Ημερομηνία"><?= fmt_date($row['movement_date']) ?></td>
     <td data-label="Πινακίδα"><?= htmlspecialchars($row['license']) ?></td>
-    <td data-label="Χιλιόμετρα"><?= htmlspecialchars($row['kilometers']) ?></td>
+    <td data-label="Χιλιόμετρα"><?= number_format($row['kilometers'],0,',','.') ?></td>
     <td data-label="Υπάλληλος"><?= htmlspecialchars($row['employee']) ?></td>
     <td data-label="Τόπος"><?= htmlspecialchars($row['workplace']) ?></td>
     <td data-label="Είδος"><?= htmlspecialchars($row['work_type']) ?></td>
@@ -117,6 +171,7 @@ $records = $stmt->fetchAll();
 </tr>
 <?php endforeach; ?>
 </table>
+</form>
 </div>
 <p style="margin-top:1em;"><a href="export.php?type=excel">Export Excel</a> | <a href="export.php?type=pdf">Export PDF</a></p>
 </div>

--- a/www.technology.gr/coder/index.php
+++ b/www.technology.gr/coder/index.php
@@ -56,13 +56,20 @@ function fmt_date($d){
     return date('d-m-Y', strtotime($d));
 }
 
+function display_text($text){
+    $safe = nl2br(htmlspecialchars($text));
+    if(mb_strlen($text)<=350) return $safe;
+    $short = nl2br(htmlspecialchars(mb_substr($text,0,350))).'...';
+    return '<span class="short-text" style="cursor:pointer;color:blue;">'.$short.'</span><span class="full-text" style="display:none;">'.$safe.'</span>';
+}
+
 // fetch dropdown lists for filters
 $licenses = $pdo->query("SELECT name FROM licenses ORDER BY name")->fetchAll(PDO::FETCH_COLUMN);
 $workplaces = $pdo->query("SELECT name FROM workplaces ORDER BY name")->fetchAll(PDO::FETCH_COLUMN);
 $work_types = ["Εκτακτη βλάβη","Προγραμματισμένο Service","Προγραμματισμένος έλεγχος","Αλλο γεγονός"];
 
 // Build filtering query
-$sql = 'SELECT * FROM car_jobs WHERE 1';
+$where = [];
 $params = [];
 $filter_date = $_GET['f_date'] ?? '';
 $filter_license = $_GET['f_license'] ?? '';
@@ -70,15 +77,26 @@ $filter_workplace = $_GET['f_workplace'] ?? '';
 $filter_work_type = $_GET['f_work_type'] ?? '';
 $filter_battery = $_GET['f_battery'] ?? '';
 $filter_tires = $_GET['f_tires'] ?? '';
-if($filter_date){ $sql .= ' AND movement_date = ?'; $params[] = $filter_date; }
-if($filter_license){ $sql .= ' AND license = ?'; $params[] = $filter_license; }
-if($filter_workplace){ $sql .= ' AND workplace = ?'; $params[] = $filter_workplace; }
-if($filter_work_type){ $sql .= ' AND work_type = ?'; $params[] = $filter_work_type; }
-if($filter_battery){ $sql .= ' AND battery = ?'; $params[] = $filter_battery; }
-if($filter_tires){ $sql .= ' AND tires = ?'; $params[] = $filter_tires; }
-$sql .= ' ORDER BY movement_date DESC, id DESC';
+if($filter_date){ $where[] = 'movement_date = ?'; $params[] = $filter_date; }
+if($filter_license){ $where[] = 'license = ?'; $params[] = $filter_license; }
+if($filter_workplace){ $where[] = 'workplace = ?'; $params[] = $filter_workplace; }
+if($filter_work_type){ $where[] = 'work_type = ?'; $params[] = $filter_work_type; }
+if($filter_battery){ $where[] = 'battery = ?'; $params[] = $filter_battery; }
+if($filter_tires){ $where[] = 'tires = ?'; $params[] = $filter_tires; }
+$whereSql = $where ? (' WHERE '.implode(' AND ', $where)) : '';
+
+$page = max(1, intval($_GET['page'] ?? 1));
+$perPage = 10;
+$offset = ($page-1)*$perPage;
+
+$countStmt = $pdo->prepare('SELECT COUNT(*) FROM car_jobs'.$whereSql);
+$countStmt->execute($params);
+$totalRecords = $countStmt->fetchColumn();
+
+$sql = 'SELECT * FROM car_jobs'.$whereSql.' ORDER BY movement_date DESC, id DESC LIMIT ? OFFSET ?';
 $stmt = $pdo->prepare($sql);
-$stmt->execute($params);
+$dataParams = array_merge($params, [$perPage, $offset]);
+$stmt->execute($dataParams);
 $records = $stmt->fetchAll();
 ?>
 <!DOCTYPE html>
@@ -98,8 +116,8 @@ $records = $stmt->fetchAll();
     @media(max-width:600px){
         table,thead,tbody,tr,th,td{display:block;}
         tr{margin-bottom:1em;}
-        th{background:#f0f0f0;}
-        th,td{border:none;padding:4px;}
+        thead tr:first-child{display:none;}
+        th,td{border:none;padding:4px;text-align:left !important;}
         td:before{content:attr(data-label);font-weight:bold;display:block;}
     }
 </style>
@@ -120,6 +138,7 @@ $records = $stmt->fetchAll();
 <div style="overflow-x:auto;">
 <form method="get">
 <table>
+<thead>
 <tr>
     <th>Ημερομηνία<br>🔍</th>
     <th>Πινακίδα<br>🔍</th>
@@ -135,7 +154,7 @@ $records = $stmt->fetchAll();
     <th>Ελαστικά<br>🔍</th>
     <th>Ενέργειες</th>
 </tr>
-<tr>
+<tr class="filters">
     <td><input type="date" name="f_date" value="<?= htmlspecialchars($filter_date) ?>" style="width:100%;"></td>
     <td>
         <select name="f_license" style="width:100%;">
@@ -145,20 +164,8 @@ $records = $stmt->fetchAll();
             <?php endforeach; ?>
         </select>
     </td>
-    <td>
-        <select name="f_battery" style="width:100%;">
-            <option value="">--</option>
-            <option value="ΝΑΙ" <?= $filter_battery=='ΝΑΙ'?'selected':'' ?>>ΝΑΙ</option>
-            <option value="ΟΧΙ" <?= $filter_battery=='ΟΧΙ'?'selected':'' ?>>ΟΧΙ</option>
-        </select>
-    </td>
-    <td>
-        <select name="f_tires" style="width:100%;">
-            <option value="">--</option>
-            <option value="ΝΑΙ" <?= $filter_tires=='ΝΑΙ'?'selected':'' ?>>ΝΑΙ</option>
-            <option value="ΟΧΙ" <?= $filter_tires=='ΟΧΙ'?'selected':'' ?>>ΟΧΙ</option>
-        </select>
-    </td>
+    <td></td>
+    <td></td>
     <td>
         <select name="f_workplace" style="width:100%;">
             <option value="">--</option>
@@ -179,15 +186,28 @@ $records = $stmt->fetchAll();
     <td></td>
     <td></td>
     <td></td>
-    <td></td>
-    <td></td>
+    <td>
+        <select name="f_battery" style="width:100%;">
+            <option value="">--</option>
+            <option value="ΝΑΙ" <?= $filter_battery=='ΝΑΙ'?'selected':'' ?>>ΝΑΙ</option>
+            <option value="ΟΧΙ" <?= $filter_battery=='ΟΧΙ'?'selected':'' ?>>ΟΧΙ</option>
+        </select>
+    </td>
+    <td>
+        <select name="f_tires" style="width:100%;">
+            <option value="">--</option>
+            <option value="ΝΑΙ" <?= $filter_tires=='ΝΑΙ'?'selected':'' ?>>ΝΑΙ</option>
+            <option value="ΟΧΙ" <?= $filter_tires=='ΟΧΙ'?'selected':'' ?>>ΟΧΙ</option>
+        </select>
+    </td>
     <td><button type="submit">OK</button> <a href="index.php">Reset</a></td>
 </tr>
+</thead>
+<tbody>
 <?php foreach ($records as $row): ?>
 <?php
     $license = htmlspecialchars($row['license']);
     $licenseDisp = '<strong>'.mb_substr($license,0,8,'UTF-8').'</strong>'.mb_substr($license,8,null,'UTF-8');
-    $descStyle = mb_strlen($row['description'])>400 ? ' style="font-size:8pt;font-family:\'Arial Narrow\',Arial,sans-serif;"' : '';
 ?>
 <tr>
     <td data-label="Ημερομηνία"><?= fmt_date($row['movement_date']) ?></td>
@@ -198,10 +218,10 @@ $records = $stmt->fetchAll();
     <td data-label="Υπάλληλος"><?= htmlspecialchars($row['employee']) ?></td>
     <td data-label="Τόπος"><?= htmlspecialchars($row['workplace']) ?></td>
     <td data-label="Είδος"><?= htmlspecialchars($row['work_type']) ?></td>
-    <td data-label="Περιγραφή"<?php echo $descStyle; ?>><?= nl2br(htmlspecialchars($row['description'])) ?></td>
+    <td data-label="Περιγραφή"><?= display_text($row['description']) ?></td>
     <td data-label="Επόμ. Serv Ημ."><?= $row['next_service_date']?fmt_date($row['next_service_date']):'' ?></td>
     <td data-label="Επόμ. Serv Χλμ" style="text-align:center;"><?= $row['next_service_km']?number_format($row['next_service_km'],0,',','.'):'' ?></td>
-    <td data-label="Σημειώσεις"><?= nl2br(htmlspecialchars($row['user_notes'])) ?></td>
+    <td data-label="Σημειώσεις"><?= display_text($row['user_notes']) ?></td>
     <td data-label="Μπαταρία" style="text-align:center;"><?= htmlspecialchars($row['battery']) ?></td>
     <td data-label="Ελαστικά" style="text-align:center;"><?= htmlspecialchars($row['tires']) ?></td>
     <td>
@@ -211,11 +231,33 @@ $records = $stmt->fetchAll();
     </td>
 </tr>
 <?php endforeach; ?>
+</tbody>
 </table>
 </form>
+</div>
+<div style="text-align:center;margin-top:0.5em;">
+<?php
+$paramsForLinks = $_GET;
+if($page>1){
+    $paramsForLinks['page']=$page-1;
+    echo '<a href="?'.http_build_query($paramsForLinks).'">&#9664;</a> ';
+}
+if($page*$perPage < $totalRecords){
+    $paramsForLinks['page']=$page+1;
+    echo '<a href="?'.http_build_query($paramsForLinks).'">&#9654;</a>';
+}
+?>
 </div>
 <p style="margin-top:1em;"><a href="export.php?type=excel">Export Excel</a> | <a href="export.php?type=pdf">Export PDF</a></p>
 </div>
 <footer>ver 1.0  (c) 2025</footer>
+<script>
+document.addEventListener('click',function(e){
+  if(e.target.classList.contains('short-text')){
+     e.target.style.display='none';
+     var full=e.target.nextElementSibling; if(full) full.style.display='inline';
+  }
+});
+</script>
 </body>
 </html>

--- a/www.technology.gr/coder/index.php
+++ b/www.technology.gr/coder/index.php
@@ -19,6 +19,7 @@ if (!isset($_SESSION['logged_in'])) {
     <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, nofollow">
     <title>Είσοδος</title>
     <style>
         body{font-family:Arial,sans-serif;padding:1em;background:#f4f4f4;}
@@ -60,14 +61,15 @@ function display_text($text){
     $safe = nl2br(htmlspecialchars($text));
     if(mb_strlen($text)<=350) return $safe;
     $short = nl2br(htmlspecialchars(mb_substr($text,0,350)));
-    $icon  = '<span class="expand" style="cursor:pointer;color:blue;">&#x2795;</span>';
-    return $short.' '.$icon.'<span class="full-text" style="display:none;">'.$safe.'</span>';
+    $expand = '<span class="expand" style="cursor:pointer;color:blue;">&#x2795;</span>';
+    $collapse = '<span class="collapse" style="cursor:pointer;color:blue;">&#x2796;</span>';
+    return $short.' '.$expand.'<span class="full-text" style="display:none;">'.$safe.' '.$collapse.'</span>';
 }
 
 // fetch dropdown lists for filters
 $licenses = $pdo->query("SELECT name FROM licenses ORDER BY name")->fetchAll(PDO::FETCH_COLUMN);
 $workplaces = $pdo->query("SELECT name FROM workplaces ORDER BY name")->fetchAll(PDO::FETCH_COLUMN);
-$work_types = ["Εκτακτη βλάβη","Προγραμματισμένο Service","Προγραμματισμένος έλεγχος","Αλλο γεγονός"];
+$work_types = $pdo->query("SELECT name FROM work_types ORDER BY name")->fetchAll(PDO::FETCH_COLUMN);
 
 // Build filtering query
 $where = [];
@@ -105,6 +107,7 @@ $records = $stmt->fetchAll();
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex, nofollow">
 <title>Καταχώρηση Εργασιών Οχημάτων</title>
 <style>
     body{font-family:Arial,sans-serif;margin:0;padding:0;}
@@ -257,6 +260,9 @@ document.addEventListener('click',function(e){
   if(e.target.classList.contains('expand')){
      e.target.style.display='none';
      var full=e.target.nextElementSibling; if(full) full.style.display='inline';
+  }else if(e.target.classList.contains('collapse')){
+     var full=e.target.parentElement; if(full) full.style.display='none';
+     var expand=full.previousElementSibling; if(expand) expand.style.display='inline';
   }
 });
 </script>

--- a/www.technology.gr/coder/index.php
+++ b/www.technology.gr/coder/index.php
@@ -86,9 +86,11 @@ $records = $stmt->fetchAll();
 <style>
     body{font-family:Arial,sans-serif;margin:0;padding:0;}
     header{padding:1em;background:#333;color:#fff;text-align:center;}
+    footer{padding:.3em;background:#333;color:#fff;font-size:12px;text-align:left;}
     .container{padding:1em;}
     table{border-collapse:collapse;width:100%;}
     th,td{border:1px solid #ccc;padding:8px;text-align:left;}
+    tbody tr:nth-child(even){background:#e8f4ff;}
     @media(max-width:600px){
         table,thead,tbody,tr,th,td{display:block;}
         tr{margin-bottom:1em;}
@@ -109,6 +111,7 @@ $records = $stmt->fetchAll();
 </nav>
 </header>
 <div class="container">
+<?php if(isset($_SESSION['warning'])){echo '<p style="color:red">'.$_SESSION['warning'].'</p>';unset($_SESSION['warning']);} ?>
 <p><a href="record.php">Νέα Καταχώρηση</a></p>
 <div style="overflow-x:auto;">
 <form method="get">
@@ -121,6 +124,11 @@ $records = $stmt->fetchAll();
     <th>Τόπος<br>🔍</th>
     <th>Είδος<br>🔍</th>
     <th>Περιγραφή</th>
+    <th>Επόμ. Serv Ημ.</th>
+    <th>Επόμ. Serv Χλμ</th>
+    <th>Σημειώσεις</th>
+    <th>Μπαταρία</th>
+    <th>Ελαστικά</th>
     <th>Ενέργειες</th>
 </tr>
 <tr>
@@ -152,6 +160,11 @@ $records = $stmt->fetchAll();
         </select>
     </td>
     <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td><button type="submit">OK</button> <a href="index.php">Reset</a></td>
 </tr>
 <?php foreach ($records as $row): ?>
@@ -163,6 +176,11 @@ $records = $stmt->fetchAll();
     <td data-label="Τόπος"><?= htmlspecialchars($row['workplace']) ?></td>
     <td data-label="Είδος"><?= htmlspecialchars($row['work_type']) ?></td>
     <td data-label="Περιγραφή"><?= nl2br(htmlspecialchars($row['description'])) ?></td>
+    <td data-label="Επόμ. Serv Ημ."><?= $row['next_service_date']?fmt_date($row['next_service_date']):'' ?></td>
+    <td data-label="Επόμ. Serv Χλμ"><?= $row['next_service_km']?number_format($row['next_service_km'],0,',','.'):'' ?></td>
+    <td data-label="Σημειώσεις"><?= nl2br(htmlspecialchars($row['user_notes'])) ?></td>
+    <td data-label="Μπαταρία"><?= htmlspecialchars($row['battery']) ?></td>
+    <td data-label="Ελαστικά"><?= htmlspecialchars($row['tires']) ?></td>
     <td>
         <a href="record.php?id=<?= $row['id'] ?>" title="Επεξεργασία" style="text-decoration:none;">✏️</a>
         |
@@ -175,5 +193,6 @@ $records = $stmt->fetchAll();
 </div>
 <p style="margin-top:1em;"><a href="export.php?type=excel">Export Excel</a> | <a href="export.php?type=pdf">Export PDF</a></p>
 </div>
+<footer>ver 1.0  (c) 2025</footer>
 </body>
 </html>

--- a/www.technology.gr/coder/index.php
+++ b/www.technology.gr/coder/index.php
@@ -68,10 +68,14 @@ $filter_date = $_GET['f_date'] ?? '';
 $filter_license = $_GET['f_license'] ?? '';
 $filter_workplace = $_GET['f_workplace'] ?? '';
 $filter_work_type = $_GET['f_work_type'] ?? '';
+$filter_battery = $_GET['f_battery'] ?? '';
+$filter_tires = $_GET['f_tires'] ?? '';
 if($filter_date){ $sql .= ' AND movement_date = ?'; $params[] = $filter_date; }
 if($filter_license){ $sql .= ' AND license = ?'; $params[] = $filter_license; }
 if($filter_workplace){ $sql .= ' AND workplace = ?'; $params[] = $filter_workplace; }
 if($filter_work_type){ $sql .= ' AND work_type = ?'; $params[] = $filter_work_type; }
+if($filter_battery){ $sql .= ' AND battery = ?'; $params[] = $filter_battery; }
+if($filter_tires){ $sql .= ' AND tires = ?'; $params[] = $filter_tires; }
 $sql .= ' ORDER BY movement_date DESC, id DESC';
 $stmt = $pdo->prepare($sql);
 $stmt->execute($params);
@@ -127,8 +131,8 @@ $records = $stmt->fetchAll();
     <th>Επόμ. Serv Ημ.</th>
     <th>Επόμ. Serv Χλμ</th>
     <th>Σημειώσεις</th>
-    <th>Μπαταρία</th>
-    <th>Ελαστικά</th>
+    <th>Μπαταρία<br>🔍</th>
+    <th>Ελαστικά<br>🔍</th>
     <th>Ενέργειες</th>
 </tr>
 <tr>
@@ -141,8 +145,20 @@ $records = $stmt->fetchAll();
             <?php endforeach; ?>
         </select>
     </td>
-    <td></td>
-    <td></td>
+    <td>
+        <select name="f_battery" style="width:100%;">
+            <option value="">--</option>
+            <option value="ΝΑΙ" <?= $filter_battery=='ΝΑΙ'?'selected':'' ?>>ΝΑΙ</option>
+            <option value="ΟΧΙ" <?= $filter_battery=='ΟΧΙ'?'selected':'' ?>>ΟΧΙ</option>
+        </select>
+    </td>
+    <td>
+        <select name="f_tires" style="width:100%;">
+            <option value="">--</option>
+            <option value="ΝΑΙ" <?= $filter_tires=='ΝΑΙ'?'selected':'' ?>>ΝΑΙ</option>
+            <option value="ΟΧΙ" <?= $filter_tires=='ΟΧΙ'?'selected':'' ?>>ΟΧΙ</option>
+        </select>
+    </td>
     <td>
         <select name="f_workplace" style="width:100%;">
             <option value="">--</option>
@@ -168,19 +184,26 @@ $records = $stmt->fetchAll();
     <td><button type="submit">OK</button> <a href="index.php">Reset</a></td>
 </tr>
 <?php foreach ($records as $row): ?>
+<?php
+    $license = htmlspecialchars($row['license']);
+    $licenseDisp = '<strong>'.mb_substr($license,0,8,'UTF-8').'</strong>'.mb_substr($license,8,null,'UTF-8');
+    $descStyle = mb_strlen($row['description'])>400 ? ' style="font-size:8pt;font-family:\'Arial Narrow\',Arial,sans-serif;"' : '';
+?>
 <tr>
     <td data-label="Ημερομηνία"><?= fmt_date($row['movement_date']) ?></td>
-    <td data-label="Πινακίδα"><?= htmlspecialchars($row['license']) ?></td>
-    <td data-label="Χιλιόμετρα"><?= number_format($row['kilometers'],0,',','.') ?></td>
+    <td data-label="Πινακίδα"><?= $licenseDisp ?></td>
+    <td data-label="Χιλιόμετρα" style="text-align:center;">
+        <?= number_format($row['kilometers'],0,',','.') ?>
+    </td>
     <td data-label="Υπάλληλος"><?= htmlspecialchars($row['employee']) ?></td>
     <td data-label="Τόπος"><?= htmlspecialchars($row['workplace']) ?></td>
     <td data-label="Είδος"><?= htmlspecialchars($row['work_type']) ?></td>
-    <td data-label="Περιγραφή"><?= nl2br(htmlspecialchars($row['description'])) ?></td>
+    <td data-label="Περιγραφή"<?php echo $descStyle; ?>><?= nl2br(htmlspecialchars($row['description'])) ?></td>
     <td data-label="Επόμ. Serv Ημ."><?= $row['next_service_date']?fmt_date($row['next_service_date']):'' ?></td>
-    <td data-label="Επόμ. Serv Χλμ"><?= $row['next_service_km']?number_format($row['next_service_km'],0,',','.'):'' ?></td>
+    <td data-label="Επόμ. Serv Χλμ" style="text-align:center;"><?= $row['next_service_km']?number_format($row['next_service_km'],0,',','.'):'' ?></td>
     <td data-label="Σημειώσεις"><?= nl2br(htmlspecialchars($row['user_notes'])) ?></td>
-    <td data-label="Μπαταρία"><?= htmlspecialchars($row['battery']) ?></td>
-    <td data-label="Ελαστικά"><?= htmlspecialchars($row['tires']) ?></td>
+    <td data-label="Μπαταρία" style="text-align:center;"><?= htmlspecialchars($row['battery']) ?></td>
+    <td data-label="Ελαστικά" style="text-align:center;"><?= htmlspecialchars($row['tires']) ?></td>
     <td>
         <a href="record.php?id=<?= $row['id'] ?>" title="Επεξεργασία" style="text-decoration:none;">✏️</a>
         |

--- a/www.technology.gr/coder/index.php
+++ b/www.technology.gr/coder/index.php
@@ -1,0 +1,124 @@
+<?php
+require 'config.php';
+session_start();
+
+// Simple login check
+if (!isset($_SESSION['logged_in'])) {
+    if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+        if ($_POST['username'] === '279902' && $_POST['password'] === '413500') {
+            $_SESSION['logged_in'] = true;
+            header('Location: index.php');
+            exit();
+        } else {
+            $error = 'Λάθος στοιχεία.';
+        }
+    }
+    ?>
+    <!DOCTYPE html>
+    <html lang="el">
+    <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Είσοδος</title>
+    <style>
+        body{font-family:Arial,sans-serif;padding:1em;background:#f4f4f4;}
+        form{max-width:300px;margin:2em auto;padding:1em;background:#fff;border-radius:5px;}
+        label{display:block;margin-bottom:.5em;}
+        input[type=text],input[type=password]{width:100%;padding:.5em;margin-bottom:1em;box-sizing:border-box;}
+        button{width:100%;padding:.5em;}
+        .error{color:red;text-align:center;}
+    </style>
+    </head>
+    <body>
+    <form method="post">
+        <h2 style="text-align:center;">Σύνδεση</h2>
+        <?php if(isset($error)) echo '<p class="error">'.$error.'</p>'; ?>
+        <label>Username: <input type="text" name="username" required></label>
+        <label>Password: <input type="password" name="password" required></label>
+        <button type="submit">Είσοδος</button>
+    </form>
+    </body>
+    </html>
+    <?php
+    exit();
+}
+
+// Handle delete action
+if (isset($_GET['delete'])) {
+    $id = intval($_GET['delete']);
+    $stmt = $pdo->prepare('DELETE FROM car_jobs WHERE id = ?');
+    $stmt->execute([$id]);
+    header('Location: index.php');
+    exit();
+}
+
+// Fetch all records
+$stmt = $pdo->query('SELECT * FROM car_jobs ORDER BY movement_date DESC, id DESC');
+$records = $stmt->fetchAll();
+?>
+<!DOCTYPE html>
+<html lang="el">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Καταχώρηση Εργασιών Οχημάτων</title>
+<style>
+    body{font-family:Arial,sans-serif;margin:0;padding:0;}
+    header{padding:1em;background:#333;color:#fff;text-align:center;}
+    .container{padding:1em;}
+    table{border-collapse:collapse;width:100%;}
+    th,td{border:1px solid #ccc;padding:8px;text-align:left;}
+    @media(max-width:600px){
+        table,thead,tbody,tr,th,td{display:block;}
+        tr{margin-bottom:1em;}
+        th{background:#f0f0f0;}
+        th,td{border:none;padding:4px;}
+        td:before{content:attr(data-label);font-weight:bold;display:block;}
+    }
+</style>
+</head>
+<body>
+<header>
+<h1>Εργασίες Οχημάτων</h1>
+<nav>
+    <a href="index.php" style="color:#fff;margin-right:10px;">Αρχική</a>
+    <a href="record.php" style="color:#fff;margin-right:10px;">Νέα Καταχώρηση</a>
+    <a href="helpers.php" style="color:#fff;">Βοηθητικά</a>
+</nav>
+</header>
+<div class="container">
+<p><a href="record.php">Νέα Καταχώρηση</a></p>
+<div style="overflow-x:auto;">
+<table>
+<tr>
+    <th>Ημερομηνία</th>
+    <th>Πινακίδα</th>
+    <th>Χιλιόμετρα</th>
+    <th>Υπάλληλος</th>
+    <th>Τόπος</th>
+    <th>Είδος</th>
+    <th>Περιγραφή</th>
+    <th>Ενέργειες</th>
+</tr>
+<?php foreach ($records as $row): ?>
+<tr>
+    <td data-label="Ημερομηνία"><?= htmlspecialchars($row['movement_date']) ?></td>
+    <td data-label="Πινακίδα"><?= htmlspecialchars($row['license']) ?></td>
+    <td data-label="Χιλιόμετρα"><?= htmlspecialchars($row['kilometers']) ?></td>
+    <td data-label="Υπάλληλος"><?= htmlspecialchars($row['employee']) ?></td>
+    <td data-label="Τόπος"><?= htmlspecialchars($row['workplace']) ?></td>
+    <td data-label="Είδος"><?= htmlspecialchars($row['work_type']) ?></td>
+    <td data-label="Περιγραφή"><?= nl2br(htmlspecialchars($row['description'])) ?></td>
+    <td>
+        <a href="record.php?id=<?= $row['id'] ?>" title="Επεξεργασία" style="text-decoration:none;">✏️</a>
+        |
+        <a href="?delete=<?= $row['id'] ?>" title="Διαγραφή" onclick="return confirm('Διαγραφή εγγραφής;');" style="color:red;text-decoration:none;">❌</a>
+    </td>
+</tr>
+<?php endforeach; ?>
+</table>
+</div>
+<p style="margin-top:1em;"><a href="export.php?type=excel">Export Excel</a> | <a href="export.php?type=pdf">Export PDF</a></p>
+</div>
+</body>
+</html>

--- a/www.technology.gr/coder/index.php
+++ b/www.technology.gr/coder/index.php
@@ -59,8 +59,9 @@ function fmt_date($d){
 function display_text($text){
     $safe = nl2br(htmlspecialchars($text));
     if(mb_strlen($text)<=350) return $safe;
-    $short = nl2br(htmlspecialchars(mb_substr($text,0,350))).'...';
-    return '<span class="short-text" style="cursor:pointer;color:blue;">'.$short.'</span><span class="full-text" style="display:none;">'.$safe.'</span>';
+    $short = nl2br(htmlspecialchars(mb_substr($text,0,350)));
+    $icon  = '<span class="expand" style="cursor:pointer;color:blue;">&#x2795;</span>';
+    return $short.' '.$icon.'<span class="full-text" style="display:none;">'.$safe.'</span>';
 }
 
 // fetch dropdown lists for filters
@@ -127,31 +128,31 @@ $records = $stmt->fetchAll();
 <h1>Εργασίες Οχημάτων</h1>
 <nav>
     <a href="index.php" style="color:#fff;margin-right:10px;">Αρχική</a>
-    <a href="record.php" style="color:#fff;margin-right:10px;">Νέα Καταχώρηση</a>
+    <a href="record.php" style="color:#fff;margin-right:10px;">Νέα Καταχώριση</a>
     <a href="calendar.php" style="color:#fff;margin-right:10px;">Ημερολόγιο</a>
     <a href="helpers.php" style="color:#fff;">Βοηθητικά</a>
 </nav>
 </header>
 <div class="container">
 <?php if(isset($_SESSION['warning'])){echo '<p style="color:red">'.$_SESSION['warning'].'</p>';unset($_SESSION['warning']);} ?>
-<p><a href="record.php">Νέα Καταχώρηση</a></p>
+<p><a href="record.php">Νέα Καταχώριση</a></p>
 <div style="overflow-x:auto;">
 <form method="get">
 <table>
 <thead>
 <tr>
-    <th>Ημερομηνία<br>🔍</th>
-    <th>Πινακίδα<br>🔍</th>
+    <th>Ημερομηνία εγγραφής<br>🔍</th>
+    <th>Οχημα<br>🔍</th>
     <th>Χιλιόμετρα</th>
     <th>Υπάλληλος</th>
     <th>Τόπος<br>🔍</th>
     <th>Είδος<br>🔍</th>
     <th>Περιγραφή</th>
-    <th>Επόμ. Serv Ημ.</th>
-    <th>Επόμ. Serv Χλμ</th>
+    <th>Ημ/νία Επόμ. Service</th>
+    <th>ΧΛΜ Επόμ. Service</th>
     <th>Σημειώσεις</th>
-    <th>Μπαταρία<br>🔍</th>
-    <th>Ελαστικά<br>🔍</th>
+    <th>Αφορά Μπαταρία<br>🔍</th>
+    <th>Αφορά Ελαστικά<br>🔍</th>
     <th>Ενέργειες</th>
 </tr>
 <tr class="filters">
@@ -200,7 +201,7 @@ $records = $stmt->fetchAll();
             <option value="ΟΧΙ" <?= $filter_tires=='ΟΧΙ'?'selected':'' ?>>ΟΧΙ</option>
         </select>
     </td>
-    <td><button type="submit">OK</button> <a href="index.php">Reset</a></td>
+    <td><button type="submit" style="background:green;color:#fff;">OK</button> <a href="index.php" title="RESET ΦΙΛΤΡΩΝ" style="text-decoration:none;">&#x21bb;</a></td>
 </tr>
 </thead>
 <tbody>
@@ -210,8 +211,8 @@ $records = $stmt->fetchAll();
     $licenseDisp = '<strong>'.mb_substr($license,0,8,'UTF-8').'</strong>'.mb_substr($license,8,null,'UTF-8');
 ?>
 <tr>
-    <td data-label="Ημερομηνία"><?= fmt_date($row['movement_date']) ?></td>
-    <td data-label="Πινακίδα"><?= $licenseDisp ?></td>
+    <td data-label="Ημερομηνία εγγραφής"><?= fmt_date($row['movement_date']) ?></td>
+    <td data-label="Οχημα"><?= $licenseDisp ?></td>
     <td data-label="Χιλιόμετρα" style="text-align:center;">
         <?= number_format($row['kilometers'],0,',','.') ?>
     </td>
@@ -219,11 +220,11 @@ $records = $stmt->fetchAll();
     <td data-label="Τόπος"><?= htmlspecialchars($row['workplace']) ?></td>
     <td data-label="Είδος"><?= htmlspecialchars($row['work_type']) ?></td>
     <td data-label="Περιγραφή"><?= display_text($row['description']) ?></td>
-    <td data-label="Επόμ. Serv Ημ."><?= $row['next_service_date']?fmt_date($row['next_service_date']):'' ?></td>
-    <td data-label="Επόμ. Serv Χλμ" style="text-align:center;"><?= $row['next_service_km']?number_format($row['next_service_km'],0,',','.'):'' ?></td>
+    <td data-label="Ημ/νία Επόμ. Service"><?= $row['next_service_date']?fmt_date($row['next_service_date']):'' ?></td>
+    <td data-label="ΧΛΜ Επόμ. Service" style="text-align:center;"><?= $row['next_service_km']?number_format($row['next_service_km'],0,',','.'):'' ?></td>
     <td data-label="Σημειώσεις"><?= display_text($row['user_notes']) ?></td>
-    <td data-label="Μπαταρία" style="text-align:center;"><?= htmlspecialchars($row['battery']) ?></td>
-    <td data-label="Ελαστικά" style="text-align:center;"><?= htmlspecialchars($row['tires']) ?></td>
+    <td data-label="Αφορά Μπαταρία" style="text-align:center;"><?= htmlspecialchars($row['battery']) ?></td>
+    <td data-label="Αφορά Ελαστικά" style="text-align:center;"><?= htmlspecialchars($row['tires']) ?></td>
     <td>
         <a href="record.php?id=<?= $row['id'] ?>" title="Επεξεργασία" style="text-decoration:none;">✏️</a>
         |
@@ -253,7 +254,7 @@ if($page*$perPage < $totalRecords){
 <footer>ver 1.0  (c) 2025</footer>
 <script>
 document.addEventListener('click',function(e){
-  if(e.target.classList.contains('short-text')){
+  if(e.target.classList.contains('expand')){
      e.target.style.display='none';
      var full=e.target.nextElementSibling; if(full) full.style.display='inline';
   }

--- a/www.technology.gr/coder/manage.php
+++ b/www.technology.gr/coder/manage.php
@@ -53,8 +53,10 @@ $items = $pdo->query("SELECT * FROM $table ORDER BY name")->fetchAll();
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title><?= $title ?></title>
 <style>
-    body{font-family:Arial,sans-serif;margin:0;padding:1em;background:#f4f4f4;}
-    h1{text-align:center;}
+    body{font-family:Arial,sans-serif;margin:0;padding:0;background:#f4f4f4;}
+    header{padding:1em;background:#333;color:#fff;text-align:center;}
+    footer{padding:.3em;background:#333;color:#fff;font-size:12px;text-align:left;}
+    h1{text-align:center;margin:0;padding:1em 0;}
     table{border-collapse:collapse;width:100%;margin-bottom:1em;}
     th,td{border:1px solid #ccc;padding:6px;text-align:left;}
     form{max-width:400px;margin:0 auto;background:#fff;padding:1em;border-radius:5px;}
@@ -66,6 +68,15 @@ $items = $pdo->query("SELECT * FROM $table ORDER BY name")->fetchAll();
 </style>
 </head>
 <body>
+<header>
+    <h1>Εργασίες Οχημάτων</h1>
+    <nav>
+        <a href="index.php" style="color:#fff;margin-right:10px;">Αρχική</a>
+        <a href="record.php" style="color:#fff;margin-right:10px;">Νέα Καταχώρηση</a>
+        <a href="calendar.php" style="color:#fff;margin-right:10px;">Ημερολόγιο</a>
+        <a href="helpers.php" style="color:#fff;">Βοηθητικά</a>
+    </nav>
+</header>
 <h1><?= $title ?></h1>
 <table>
 <tr><th>Όνομα</th><th>Ενέργειες</th></tr>
@@ -88,5 +99,6 @@ $items = $pdo->query("SELECT * FROM $table ORDER BY name")->fetchAll();
     <button type="submit">Αποθήκευση</button>
     <a href="helpers.php">Πίσω</a>
 </form>
+<footer>ver 1.0  (c) 2025</footer>
 </body>
 </html>

--- a/www.technology.gr/coder/manage.php
+++ b/www.technology.gr/coder/manage.php
@@ -9,7 +9,8 @@ $entity = isset($_GET['entity']) ? $_GET['entity'] : '';
 $names = [
     'licenses' => 'Πινακίδες',
     'employees' => 'Υπάλληλοι',
-    'workplaces' => 'Τόποι Εργασίας'
+    'workplaces' => 'Τόποι Εργασίας',
+    'work_types' => 'Είδη Εργασίας'
 ];
 if (!isset($names[$entity])) {
     exit('Invalid entity');
@@ -51,6 +52,7 @@ $items = $pdo->query("SELECT * FROM $table ORDER BY name")->fetchAll();
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex, nofollow">
 <title><?= $title ?></title>
 <style>
     body{font-family:Arial,sans-serif;margin:0;padding:0;background:#f4f4f4;}

--- a/www.technology.gr/coder/manage.php
+++ b/www.technology.gr/coder/manage.php
@@ -64,6 +64,7 @@ $items = $pdo->query("SELECT * FROM $table ORDER BY name")->fetchAll();
     input{width:100%;padding:.5em;margin-top:.2em;box-sizing:border-box;}
     button,a{padding:.5px 1em;margin-top:.5em;display:inline-block;}
     a{background:#ccc;color:#000;text-decoration:none;border-radius:4px;}
+    header nav a{display:inline-block;margin-right:10px;color:#fff;text-decoration:none;background:none;padding:0;}
     button{background:#007bff;color:#fff;border:none;border-radius:4px;}
 </style>
 </head>

--- a/www.technology.gr/coder/manage.php
+++ b/www.technology.gr/coder/manage.php
@@ -1,0 +1,92 @@
+<?php
+require 'config.php';
+session_start();
+if (!isset($_SESSION['logged_in'])) {
+    header('Location: index.php');
+    exit();
+}
+$entity = isset($_GET['entity']) ? $_GET['entity'] : '';
+$names = [
+    'licenses' => 'Πινακίδες',
+    'employees' => 'Υπάλληλοι',
+    'workplaces' => 'Τόποι Εργασίας'
+];
+if (!isset($names[$entity])) {
+    exit('Invalid entity');
+}
+$table = $entity;
+$title = $names[$entity];
+$id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+
+if (isset($_GET['delete'])) {
+    $stmt = $pdo->prepare("DELETE FROM $table WHERE id=?");
+    $stmt->execute([intval($_GET['delete'])]);
+    header("Location: manage.php?entity=$entity");
+    exit();
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = trim($_POST['name']);
+    if ($id) {
+        $stmt = $pdo->prepare("UPDATE $table SET name=? WHERE id=?");
+        $stmt->execute([$name, $id]);
+    } else {
+        $stmt = $pdo->prepare("INSERT INTO $table (name) VALUES (?)");
+        $stmt->execute([$name]);
+    }
+    header("Location: manage.php?entity=$entity");
+    exit();
+}
+
+$item = ['name' => ''];
+if ($id) {
+    $stmt = $pdo->prepare("SELECT * FROM $table WHERE id=?");
+    $stmt->execute([$id]);
+    $item = $stmt->fetch();
+}
+$items = $pdo->query("SELECT * FROM $table ORDER BY name")->fetchAll();
+?>
+<!DOCTYPE html>
+<html lang="el">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?= $title ?></title>
+<style>
+    body{font-family:Arial,sans-serif;margin:0;padding:1em;background:#f4f4f4;}
+    h1{text-align:center;}
+    table{border-collapse:collapse;width:100%;margin-bottom:1em;}
+    th,td{border:1px solid #ccc;padding:6px;text-align:left;}
+    form{max-width:400px;margin:0 auto;background:#fff;padding:1em;border-radius:5px;}
+    label{display:block;margin-bottom:.5em;}
+    input{width:100%;padding:.5em;margin-top:.2em;box-sizing:border-box;}
+    button,a{padding:.5px 1em;margin-top:.5em;display:inline-block;}
+    a{background:#ccc;color:#000;text-decoration:none;border-radius:4px;}
+    button{background:#007bff;color:#fff;border:none;border-radius:4px;}
+</style>
+</head>
+<body>
+<h1><?= $title ?></h1>
+<table>
+<tr><th>Όνομα</th><th>Ενέργειες</th></tr>
+<?php foreach($items as $row): ?>
+<tr>
+    <td><?= htmlspecialchars($row['name']) ?></td>
+    <td>
+        <a href="manage.php?entity=<?= $entity ?>&id=<?= $row['id'] ?>">✏️</a>
+        |
+        <a href="manage.php?entity=<?= $entity ?>&delete=<?= $row['id'] ?>" onclick="return confirm('Διαγραφή;');" style="color:red;">❌</a>
+    </td>
+</tr>
+<?php endforeach; ?>
+</table>
+<form method="post">
+    <input type="hidden" name="id" value="<?= $id ?>">
+    <label>Όνομα:
+        <input type="text" name="name" value="<?= htmlspecialchars($item['name']) ?>" required>
+    </label>
+    <button type="submit">Αποθήκευση</button>
+    <a href="helpers.php">Πίσω</a>
+</form>
+</body>
+</html>

--- a/www.technology.gr/coder/manage.php
+++ b/www.technology.gr/coder/manage.php
@@ -73,7 +73,7 @@ $items = $pdo->query("SELECT * FROM $table ORDER BY name")->fetchAll();
     <h1>Εργασίες Οχημάτων</h1>
     <nav>
         <a href="index.php" style="color:#fff;margin-right:10px;">Αρχική</a>
-        <a href="record.php" style="color:#fff;margin-right:10px;">Νέα Καταχώρηση</a>
+        <a href="record.php" style="color:#fff;margin-right:10px;">Νέα Καταχώριση</a>
         <a href="calendar.php" style="color:#fff;margin-right:10px;">Ημερολόγιο</a>
         <a href="helpers.php" style="color:#fff;">Βοηθητικά</a>
     </nav>

--- a/www.technology.gr/coder/record.php
+++ b/www.technology.gr/coder/record.php
@@ -1,0 +1,122 @@
+<?php
+require 'config.php';
+session_start();
+if (!isset($_SESSION['logged_in'])) {
+    header('Location: index.php');
+    exit();
+}
+
+// Fetch dropdown options from helper tables
+$licenses = $pdo->query("SELECT name FROM licenses ORDER BY name")->fetchAll(PDO::FETCH_COLUMN);
+$workplaces = $pdo->query("SELECT name FROM workplaces ORDER BY name")->fetchAll(PDO::FETCH_COLUMN);
+$employees = $pdo->query("SELECT name FROM employees ORDER BY name")->fetchAll(PDO::FETCH_COLUMN);
+$work_types = ["Εκτακτη βλάβη","Προγραμματισμένο Service","Προγραμματισμένος έλεγχος","Αλλο γεγονός"];
+
+$id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    // Save form
+    $data = [
+        'movement_date' => $_POST['movement_date'],
+        'license' => $_POST['license'],
+        'kilometers' => intval($_POST['kilometers']),
+        'employee' => $_POST['employee'],
+        'workplace' => $_POST['workplace'],
+        'work_type' => $_POST['work_type'],
+        'description' => $_POST['description'],
+    ];
+    if ($id) {
+        // update
+        $sql = "UPDATE car_jobs SET movement_date=:movement_date, license=:license, kilometers=:kilometers, employee=:employee, workplace=:workplace, work_type=:work_type, description=:description WHERE id=:id";
+        $stmt = $pdo->prepare($sql);
+        $data['id'] = $id;
+        $stmt->execute($data);
+    } else {
+        // insert
+        $sql = "INSERT INTO car_jobs (movement_date, license, kilometers, employee, workplace, work_type, description) VALUES (:movement_date,:license,:kilometers,:employee,:workplace,:work_type,:description)";
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($data);
+        $id = $pdo->lastInsertId();
+    }
+    header('Location: index.php');
+    exit();
+}
+
+// If editing, fetch existing data
+$record = [
+    'movement_date' => date('Y-m-d'),
+    'license' => '',
+    'kilometers' => '',
+    'employee' => '',
+    'workplace' => '',
+    'work_type' => '',
+    'description' => ''
+];
+if ($id) {
+    $stmt = $pdo->prepare('SELECT * FROM car_jobs WHERE id = ?');
+    $stmt->execute([$id]);
+    $record = $stmt->fetch();
+}
+?>
+<!DOCTYPE html>
+<html lang="el">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?= $id ? 'Επεξεργασία' : 'Νέα' ?> Εργασία Οχήματος</title>
+<style>
+    body{font-family:Arial,sans-serif;margin:0;padding:1em;background:#f4f4f4;}
+    h1{text-align:center;}
+    form{max-width:600px;margin:0 auto;background:#fff;padding:1em;border-radius:5px;}
+    label{display:block;margin-bottom:.5em;}
+    input,select,textarea{width:100%;padding:.5em;margin-top:.2em;box-sizing:border-box;}
+    button,a{padding:.5em 1em;margin-top:1em;display:inline-block;}
+    a{background:#ccc;color:#000;text-decoration:none;border-radius:4px;}
+    button{background:#007bff;color:#fff;border:none;border-radius:4px;}
+</style>
+</head>
+<body>
+<h1><?= $id ? 'Επεξεργασία' : 'Νέα' ?> Εργασία Οχήματος</h1>
+<form method="post">
+    <label>Ημερομηνία κίνησης: <input type="date" name="movement_date" value="<?= htmlspecialchars($record['movement_date']) ?>" required></label><br>
+    <label>Αριθμός πινακίδας:
+        <select name="license" required>
+            <option value="">--Επιλογή--</option>
+            <?php foreach ($licenses as $opt): ?>
+            <option value="<?= $opt ?>" <?= $record['license']==$opt?'selected':'' ?>><?= $opt ?></option>
+            <?php endforeach; ?>
+        </select>
+    </label><br>
+    <label>Χιλιόμετρα: <input type="number" name="kilometers" value="<?= htmlspecialchars($record['kilometers']) ?>" required></label><br>
+    <label>Υπάλληλος:
+        <select name="employee" required>
+            <option value="">--Επιλογή--</option>
+            <?php foreach ($employees as $opt): ?>
+            <option value="<?= $opt ?>" <?= $record['employee']==$opt?'selected':'' ?>><?= $opt ?></option>
+            <?php endforeach; ?>
+        </select>
+    </label><br>
+    <label>Τόπος εργασίας:
+        <select name="workplace" required>
+            <option value="">--Επιλογή--</option>
+            <?php foreach ($workplaces as $opt): ?>
+            <option value="<?= $opt ?>" <?= $record['workplace']==$opt?'selected':'' ?>><?= $opt ?></option>
+            <?php endforeach; ?>
+        </select>
+    </label><br>
+    <label>Είδος εργασίας:
+        <select name="work_type" required>
+            <option value="">--Επιλογή--</option>
+            <?php foreach ($work_types as $opt): ?>
+            <option value="<?= $opt ?>" <?= $record['work_type']==$opt?'selected':'' ?>><?= $opt ?></option>
+            <?php endforeach; ?>
+        </select>
+    </label><br>
+    <label>Περιγραφή:<br>
+        <textarea name="description" rows="4" cols="50"><?= htmlspecialchars($record['description']) ?></textarea>
+    </label><br>
+    <button type="submit">Αποθήκευση</button>
+    <a href="index.php">Ακύρωση</a>
+</form>
+</body>
+</html>

--- a/www.technology.gr/coder/record.php
+++ b/www.technology.gr/coder/record.php
@@ -24,19 +24,41 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         'workplace' => $_POST['workplace'],
         'work_type' => $_POST['work_type'],
         'description' => $_POST['description'],
+        'next_service_date' => $_POST['next_service_date'] ?: null,
+        'next_service_km' => $_POST['next_service_km'] !== '' ? intval($_POST['next_service_km']) : null,
+        'user_notes' => $_POST['user_notes'],
+        'battery' => $_POST['battery'] ?? 'ΟΧΙ',
+        'tires' => $_POST['tires'] ?? 'ΟΧΙ',
     ];
+
+    $warnings = [];
+    $stmt = $pdo->prepare('SELECT kilometers FROM car_jobs WHERE license=? ORDER BY movement_date DESC, id DESC LIMIT 1');
+    $stmt->execute([$data['license']]);
+    $lastKm = $stmt->fetchColumn();
+    if($lastKm !== false && $data['kilometers'] < $lastKm){
+        $warnings[] = 'Προειδοποίηση: μικρότερα χιλιόμετρα από την τελευταία καταχώριση.';
+    }
+    if($data['next_service_date'] && $data['next_service_date'] <= $data['movement_date']){
+        $warnings[] = 'Προειδοποίηση: η ημερομηνία επόμενου service είναι προγενέστερη.';
+    }
+    if($data['next_service_km'] !== null && $data['next_service_km'] <= $data['kilometers']){
+        $warnings[] = 'Προειδοποίηση: τα χιλιόμετρα επόμενου service είναι μικρότερα.';
+    }
     if ($id) {
         // update
-        $sql = "UPDATE car_jobs SET movement_date=:movement_date, license=:license, kilometers=:kilometers, employee=:employee, workplace=:workplace, work_type=:work_type, description=:description WHERE id=:id";
+        $sql = "UPDATE car_jobs SET movement_date=:movement_date, license=:license, kilometers=:kilometers, employee=:employee, workplace=:workplace, work_type=:work_type, description=:description, next_service_date=:next_service_date, next_service_km=:next_service_km, user_notes=:user_notes, battery=:battery, tires=:tires WHERE id=:id";
         $stmt = $pdo->prepare($sql);
         $data['id'] = $id;
         $stmt->execute($data);
     } else {
         // insert
-        $sql = "INSERT INTO car_jobs (movement_date, license, kilometers, employee, workplace, work_type, description) VALUES (:movement_date,:license,:kilometers,:employee,:workplace,:work_type,:description)";
+        $sql = "INSERT INTO car_jobs (movement_date, license, kilometers, employee, workplace, work_type, description, next_service_date, next_service_km, user_notes, battery, tires) VALUES (:movement_date,:license,:kilometers,:employee,:workplace,:work_type,:description,:next_service_date,:next_service_km,:user_notes,:battery,:tires)";
         $stmt = $pdo->prepare($sql);
         $stmt->execute($data);
         $id = $pdo->lastInsertId();
+    }
+    if($warnings){
+        $_SESSION['warning'] = implode(' ', $warnings);
     }
     header('Location: index.php');
     exit();
@@ -50,7 +72,12 @@ $record = [
     'employee' => '',
     'workplace' => '',
     'work_type' => '',
-    'description' => ''
+    'description' => '',
+    'next_service_date' => '',
+    'next_service_km' => '',
+    'user_notes' => '',
+    'battery' => 'ΟΧΙ',
+    'tires' => 'ΟΧΙ'
 ];
 if ($id) {
     $stmt = $pdo->prepare('SELECT * FROM car_jobs WHERE id = ?');
@@ -65,8 +92,10 @@ if ($id) {
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title><?= $id ? 'Επεξεργασία' : 'Νέα' ?> Εργασία Οχήματος</title>
 <style>
-    body{font-family:Arial,sans-serif;margin:0;padding:1em;background:#f4f4f4;}
-    h1{text-align:center;}
+    body{font-family:Arial,sans-serif;margin:0;padding:0;background:#f4f4f4;}
+    header{padding:1em;background:#333;color:#fff;text-align:center;}
+    footer{padding:.3em;background:#333;color:#fff;font-size:12px;text-align:left;}
+    h1{text-align:center;margin:0;padding:1em 0;}
     form{max-width:600px;margin:0 auto;background:#fff;padding:1em;border-radius:5px;}
     label{display:block;margin-bottom:.5em;}
     input,select,textarea{width:100%;padding:.5em;margin-top:.2em;box-sizing:border-box;}
@@ -76,6 +105,15 @@ if ($id) {
 </style>
 </head>
 <body>
+<header>
+    <h1>Εργασίες Οχημάτων</h1>
+    <nav>
+        <a href="index.php" style="color:#fff;margin-right:10px;">Αρχική</a>
+        <a href="record.php" style="color:#fff;margin-right:10px;">Νέα Καταχώρηση</a>
+        <a href="calendar.php" style="color:#fff;margin-right:10px;">Ημερολόγιο</a>
+        <a href="helpers.php" style="color:#fff;">Βοηθητικά</a>
+    </nav>
+</header>
 <h1><?= $id ? 'Επεξεργασία' : 'Νέα' ?> Εργασία Οχήματος</h1>
 <form method="post">
     <label>Ημερομηνία κίνησης: <input type="date" name="movement_date" value="<?= htmlspecialchars($record['movement_date']) ?>" required></label><br>
@@ -115,8 +153,26 @@ if ($id) {
     <label>Περιγραφή:<br>
         <textarea name="description" rows="4" cols="50"><?= htmlspecialchars($record['description']) ?></textarea>
     </label><br>
+    <label>Ημερομηνία επόμενου Service: <input type="date" name="next_service_date" value="<?= htmlspecialchars($record['next_service_date']) ?>"></label><br>
+    <label>Χιλιόμετρα επόμενου Service: <input type="number" name="next_service_km" value="<?= htmlspecialchars($record['next_service_km']) ?>"></label><br>
+    <label>Σημειώσεις χρήστη:<br>
+        <textarea name="user_notes" rows="2" cols="50"><?= htmlspecialchars($record['user_notes']) ?></textarea>
+    </label><br>
+    <label>Αφορά μπαταρία:
+        <select name="battery">
+            <option value="ΟΧΙ" <?= $record['battery']=='ΟΧΙ'?'selected':'' ?>>ΟΧΙ</option>
+            <option value="ΝΑΙ" <?= $record['battery']=='ΝΑΙ'?'selected':'' ?>>ΝΑΙ</option>
+        </select>
+    </label><br>
+    <label>Αφορά ελαστικά:
+        <select name="tires">
+            <option value="ΟΧΙ" <?= $record['tires']=='ΟΧΙ'?'selected':'' ?>>ΟΧΙ</option>
+            <option value="ΝΑΙ" <?= $record['tires']=='ΝΑΙ'?'selected':'' ?>>ΝΑΙ</option>
+        </select>
+    </label><br>
     <button type="submit">Αποθήκευση</button>
     <a href="index.php">Ακύρωση</a>
 </form>
+<footer>ver 1.0  (c) 2025</footer>
 </body>
 </html>

--- a/www.technology.gr/coder/record.php
+++ b/www.technology.gr/coder/record.php
@@ -83,6 +83,8 @@ if ($id) {
     $stmt = $pdo->prepare('SELECT * FROM car_jobs WHERE id = ?');
     $stmt->execute([$id]);
     $record = $stmt->fetch();
+} elseif(isset($_GET['service_date'])) {
+    $record['next_service_date'] = $_GET['service_date'];
 }
 ?>
 <!DOCTYPE html>

--- a/www.technology.gr/coder/record.php
+++ b/www.technology.gr/coder/record.php
@@ -10,7 +10,7 @@ if (!isset($_SESSION['logged_in'])) {
 $licenses = $pdo->query("SELECT name FROM licenses ORDER BY name")->fetchAll(PDO::FETCH_COLUMN);
 $workplaces = $pdo->query("SELECT name FROM workplaces ORDER BY name")->fetchAll(PDO::FETCH_COLUMN);
 $employees = $pdo->query("SELECT name FROM employees ORDER BY name")->fetchAll(PDO::FETCH_COLUMN);
-$work_types = ["Εκτακτη βλάβη","Προγραμματισμένο Service","Προγραμματισμένος έλεγχος","Αλλο γεγονός"];
+$work_types = $pdo->query("SELECT name FROM work_types ORDER BY name")->fetchAll(PDO::FETCH_COLUMN);
 
 $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
 
@@ -104,6 +104,7 @@ if ($id) {
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex, nofollow">
 <title><?= $id ? 'Επεξεργασία' : 'Νέα' ?> Εργασία Οχήματος</title>
 <style>
     body{font-family:Arial,sans-serif;margin:0;padding:0;background:#f4f4f4;}

--- a/www.technology.gr/coder/record.php
+++ b/www.technology.gr/coder/record.php
@@ -31,6 +31,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         'tires' => $_POST['tires'] ?? 'ΟΧΙ',
     ];
 
+    $errors = [];
+    $minDate = '2025-01-01';
+    if($data['kilometers'] > 900000) $errors[] = 'Χιλιόμετρα έως 900000.';
+    if($data['next_service_km'] !== null && $data['next_service_km'] > 900000) $errors[] = 'ΧΛΜ επόμενου service έως 900000.';
+    if($data['movement_date'] && $data['movement_date'] <= $minDate) $errors[] = 'Ημερομηνία εγγραφής μετά την 01-01-2025.';
+    if($data['next_service_date'] && $data['next_service_date'] <= $minDate) $errors[] = 'Ημ/νία επόμενου service μετά την 01-01-2025.';
+
     $warnings = [];
     $stmt = $pdo->prepare('SELECT kilometers FROM car_jobs WHERE license=? ORDER BY movement_date DESC, id DESC LIMIT 1');
     $stmt->execute([$data['license']]);
@@ -44,24 +51,29 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if($data['next_service_km'] !== null && $data['next_service_km'] <= $data['kilometers']){
         $warnings[] = 'Προειδοποίηση: τα χιλιόμετρα επόμενου service είναι μικρότερα.';
     }
-    if ($id) {
-        // update
-        $sql = "UPDATE car_jobs SET movement_date=:movement_date, license=:license, kilometers=:kilometers, employee=:employee, workplace=:workplace, work_type=:work_type, description=:description, next_service_date=:next_service_date, next_service_km=:next_service_km, user_notes=:user_notes, battery=:battery, tires=:tires WHERE id=:id";
-        $stmt = $pdo->prepare($sql);
-        $data['id'] = $id;
-        $stmt->execute($data);
+    if(empty($errors)){
+        if ($id) {
+            // update
+            $sql = "UPDATE car_jobs SET movement_date=:movement_date, license=:license, kilometers=:kilometers, employee=:employee, workplace=:workplace, work_type=:work_type, description=:description, next_service_date=:next_service_date, next_service_km=:next_service_km, user_notes=:user_notes, battery=:battery, tires=:tires WHERE id=:id";
+            $stmt = $pdo->prepare($sql);
+            $data['id'] = $id;
+            $stmt->execute($data);
+        } else {
+            // insert
+            $sql = "INSERT INTO car_jobs (movement_date, license, kilometers, employee, workplace, work_type, description, next_service_date, next_service_km, user_notes, battery, tires) VALUES (:movement_date,:license,:kilometers,:employee,:workplace,:work_type,:description,:next_service_date,:next_service_km,:user_notes,:battery,:tires)";
+            $stmt = $pdo->prepare($sql);
+            $stmt->execute($data);
+            $id = $pdo->lastInsertId();
+        }
+        if($warnings){
+            $_SESSION['warning'] = implode(' ', $warnings);
+        }
+        header('Location: index.php');
+        exit();
     } else {
-        // insert
-        $sql = "INSERT INTO car_jobs (movement_date, license, kilometers, employee, workplace, work_type, description, next_service_date, next_service_km, user_notes, battery, tires) VALUES (:movement_date,:license,:kilometers,:employee,:workplace,:work_type,:description,:next_service_date,:next_service_km,:user_notes,:battery,:tires)";
-        $stmt = $pdo->prepare($sql);
-        $stmt->execute($data);
-        $id = $pdo->lastInsertId();
+        $error = implode(' ', $errors);
+        $record = array_merge($record, $_POST);
     }
-    if($warnings){
-        $_SESSION['warning'] = implode(' ', $warnings);
-    }
-    header('Location: index.php');
-    exit();
 }
 
 // If editing, fetch existing data
@@ -111,15 +123,18 @@ if ($id) {
     <h1>Εργασίες Οχημάτων</h1>
     <nav>
         <a href="index.php" style="color:#fff;margin-right:10px;">Αρχική</a>
-        <a href="record.php" style="color:#fff;margin-right:10px;">Νέα Καταχώρηση</a>
+        <a href="record.php" style="color:#fff;margin-right:10px;">Νέα Καταχώριση</a>
         <a href="calendar.php" style="color:#fff;margin-right:10px;">Ημερολόγιο</a>
         <a href="helpers.php" style="color:#fff;">Βοηθητικά</a>
     </nav>
 </header>
 <h1><?= $id ? 'Επεξεργασία' : 'Νέα' ?> Εργασία Οχήματος</h1>
+<?php if(isset($error)): ?>
+<p style="color:red;text-align:center;"><?= htmlspecialchars($error) ?></p>
+<?php endif; ?>
 <form method="post">
-    <label>Ημερομηνία κίνησης: <input type="date" name="movement_date" value="<?= htmlspecialchars($record['movement_date']) ?>" required></label><br>
-    <label>Αριθμός πινακίδας:
+    <label>Ημερομηνία εγγραφής: <input type="date" name="movement_date" min="2025-01-02" value="<?= htmlspecialchars($record['movement_date']) ?>" required></label><br>
+    <label>Όχημα:
         <select name="license" required>
             <option value="">--Επιλογή--</option>
             <?php foreach ($licenses as $opt): ?>
@@ -127,7 +142,7 @@ if ($id) {
             <?php endforeach; ?>
         </select>
     </label><br>
-    <label>Χιλιόμετρα: <input type="number" name="kilometers" value="<?= htmlspecialchars($record['kilometers']) ?>" required></label><br>
+    <label>Χιλιόμετρα: <input type="number" name="kilometers" max="900000" value="<?= htmlspecialchars($record['kilometers']) ?>" required></label><br>
     <label>Υπάλληλος:
         <select name="employee" required>
             <option value="">--Επιλογή--</option>
@@ -155,18 +170,18 @@ if ($id) {
     <label>Περιγραφή:<br>
         <textarea name="description" rows="4" cols="50"><?= htmlspecialchars($record['description']) ?></textarea>
     </label><br>
-    <label>Ημερομηνία επόμενου Service: <input type="date" name="next_service_date" value="<?= htmlspecialchars($record['next_service_date']) ?>"></label><br>
-    <label>Χιλιόμετρα επόμενου Service: <input type="number" name="next_service_km" value="<?= htmlspecialchars($record['next_service_km']) ?>"></label><br>
+    <label>Ημ/νία Επόμ. Service: <input type="date" name="next_service_date" min="2025-01-02" value="<?= htmlspecialchars($record['next_service_date']) ?>"></label><br>
+    <label>ΧΛΜ Επόμ. Service: <input type="number" name="next_service_km" max="900000" value="<?= htmlspecialchars($record['next_service_km']) ?>"></label><br>
     <label>Σημειώσεις χρήστη:<br>
         <textarea name="user_notes" rows="2" cols="50"><?= htmlspecialchars($record['user_notes']) ?></textarea>
     </label><br>
-    <label>Αφορά μπαταρία:
+    <label>Αφορά Μπαταρία:
         <select name="battery">
             <option value="ΟΧΙ" <?= $record['battery']=='ΟΧΙ'?'selected':'' ?>>ΟΧΙ</option>
             <option value="ΝΑΙ" <?= $record['battery']=='ΝΑΙ'?'selected':'' ?>>ΝΑΙ</option>
         </select>
     </label><br>
-    <label>Αφορά ελαστικά:
+    <label>Αφορά Ελαστικά:
         <select name="tires">
             <option value="ΟΧΙ" <?= $record['tires']=='ΟΧΙ'?'selected':'' ?>>ΟΧΙ</option>
             <option value="ΝΑΙ" <?= $record['tires']=='ΝΑΙ'?'selected':'' ?>>ΝΑΙ</option>

--- a/www.technology.gr/coder/setup.php
+++ b/www.technology.gr/coder/setup.php
@@ -1,7 +1,14 @@
 <?php
 require 'config.php';
 
-$sql = "CREATE TABLE IF NOT EXISTS car_jobs (
+function columnExists(PDO $pdo, string $table, string $column): bool {
+    $stmt = $pdo->prepare("SHOW COLUMNS FROM `$table` LIKE ?");
+    $stmt->execute([$column]);
+    return (bool)$stmt->fetch();
+}
+
+// main records table
+$pdo->exec("CREATE TABLE IF NOT EXISTS car_jobs (
     id INT AUTO_INCREMENT PRIMARY KEY,
     movement_date DATE NOT NULL,
     license VARCHAR(20) NOT NULL,
@@ -9,41 +16,48 @@ $sql = "CREATE TABLE IF NOT EXISTS car_jobs (
     employee VARCHAR(100) NOT NULL,
     workplace VARCHAR(50) NOT NULL,
     work_type VARCHAR(100) NOT NULL,
-    description TEXT,
-    next_service_date DATE DEFAULT NULL,
-    next_service_km INT DEFAULT NULL,
-    user_notes TEXT,
-    battery VARCHAR(3) NOT NULL DEFAULT 'ΟΧΙ',
-    tires VARCHAR(3) NOT NULL DEFAULT 'ΟΧΙ'
-) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci";
-$pdo->exec($sql);
+    description TEXT
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
 
-$sql = "CREATE TABLE IF NOT EXISTS licenses (
+$extraColumns = [
+    'next_service_date DATE DEFAULT NULL',
+    'next_service_km INT DEFAULT NULL',
+    'user_notes TEXT',
+    "battery VARCHAR(3) NOT NULL DEFAULT 'ΟΧΙ'",
+    "tires VARCHAR(3) NOT NULL DEFAULT 'ΟΧΙ'"
+];
+foreach ($extraColumns as $def) {
+    preg_match('/^([^ ]+)/', $def, $m);
+    $col = $m[1];
+    if (!columnExists($pdo, 'car_jobs', $col)) {
+        $pdo->exec("ALTER TABLE car_jobs ADD $def");
+    }
+}
+
+// helper tables
+$pdo->exec("CREATE TABLE IF NOT EXISTS licenses (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(20) NOT NULL
-) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci";
-$pdo->exec($sql);
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
 if (!$pdo->query('SELECT COUNT(*) FROM licenses')->fetchColumn()) {
     $pdo->exec("INSERT INTO licenses (name) VALUES ('11111'),('222222'),('333333')");
 }
 
-$sql = "CREATE TABLE IF NOT EXISTS employees (
+$pdo->exec("CREATE TABLE IF NOT EXISTS employees (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(100) NOT NULL
-) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci";
-$pdo->exec($sql);
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
 if (!$pdo->query('SELECT COUNT(*) FROM employees')->fetchColumn()) {
     $pdo->exec("INSERT INTO employees (name) VALUES ('Υπάλληλος 1'),('Υπάλληλος 2'),('Υπάλληλος 3')");
 }
 
-$sql = "CREATE TABLE IF NOT EXISTS workplaces (
+$pdo->exec("CREATE TABLE IF NOT EXISTS workplaces (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(100) NOT NULL
-) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci";
-$pdo->exec($sql);
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
 if (!$pdo->query('SELECT COUNT(*) FROM workplaces')->fetchColumn()) {
     $pdo->exec("INSERT INTO workplaces (name) VALUES ('Εντός ΔΑΑΘ'),('Εξωτερικό Συνεργείο'),('ΥΤΕΒΕ')");
 }
 
-echo "Tables created or already exist.";
+echo 'Setup complete.';
 ?>

--- a/www.technology.gr/coder/setup.php
+++ b/www.technology.gr/coder/setup.php
@@ -79,5 +79,21 @@ if (!$pdo->query('SELECT COUNT(*) FROM workplaces')->fetchColumn()) {
     echo "Ο πίνακας workplaces έχει ήδη δεδομένα.<br>\n";
 }
 
+$pdo->exec("CREATE TABLE IF NOT EXISTS work_types (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+echo "Έλεγχος πίνακα work_types...<br>\n";
+if (!$pdo->query('SELECT COUNT(*) FROM work_types')->fetchColumn()) {
+    $pdo->exec("INSERT INTO work_types (name) VALUES
+        ('Εκτακτη βλάβη'),
+        ('Προγραμματισμένο Service'),
+        ('Προγραμματισμένος έλεγχος'),
+        ('Αλλο γεγονός')");
+    echo "Προστέθηκαν default work types.<br>\n";
+} else {
+    echo "Ο πίνακας work_types έχει ήδη δεδομένα.<br>\n";
+}
+
 echo "Setup complete.<br>\n";
 ?>

--- a/www.technology.gr/coder/setup.php
+++ b/www.technology.gr/coder/setup.php
@@ -1,6 +1,8 @@
 <?php
 require 'config.php';
 
+echo "Ξεκίνημα setup...<br>\n";
+
 function columnExists(PDO $pdo, string $table, string $column): bool {
     $stmt = $pdo->prepare("SHOW COLUMNS FROM `$table` LIKE ?");
     $stmt->execute([$column]);
@@ -8,6 +10,7 @@ function columnExists(PDO $pdo, string $table, string $column): bool {
 }
 
 // main records table
+echo "Δημιουργία πίνακα car_jobs...<br>\n";
 $pdo->exec("CREATE TABLE IF NOT EXISTS car_jobs (
     id INT AUTO_INCREMENT PRIMARY KEY,
     movement_date DATE NOT NULL,
@@ -18,6 +21,7 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS car_jobs (
     work_type VARCHAR(100) NOT NULL,
     description TEXT
 ) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+echo "Πίνακας car_jobs ΟΚ.<br>\n";
 
 $extraColumns = [
     'next_service_date DATE DEFAULT NULL',
@@ -29,8 +33,12 @@ $extraColumns = [
 foreach ($extraColumns as $def) {
     preg_match('/^([^ ]+)/', $def, $m);
     $col = $m[1];
+    echo "Έλεγχος στήλης $col...<br>\n";
     if (!columnExists($pdo, 'car_jobs', $col)) {
         $pdo->exec("ALTER TABLE car_jobs ADD $def");
+        echo "Προστέθηκε η στήλη $col.<br>\n";
+    } else {
+        echo "Η στήλη $col υπάρχει ήδη.<br>\n";
     }
 }
 
@@ -39,25 +47,37 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS licenses (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(20) NOT NULL
 ) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+echo "Έλεγχος πίνακα licenses...<br>\n";
 if (!$pdo->query('SELECT COUNT(*) FROM licenses')->fetchColumn()) {
     $pdo->exec("INSERT INTO licenses (name) VALUES ('11111'),('222222'),('333333')");
+    echo "Προστέθηκαν default licenses.<br>\n";
+} else {
+    echo "Ο πίνακας licenses έχει ήδη δεδομένα.<br>\n";
 }
 
 $pdo->exec("CREATE TABLE IF NOT EXISTS employees (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(100) NOT NULL
 ) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+echo "Έλεγχος πίνακα employees...<br>\n";
 if (!$pdo->query('SELECT COUNT(*) FROM employees')->fetchColumn()) {
     $pdo->exec("INSERT INTO employees (name) VALUES ('Υπάλληλος 1'),('Υπάλληλος 2'),('Υπάλληλος 3')");
+    echo "Προστέθηκαν default employees.<br>\n";
+} else {
+    echo "Ο πίνακας employees έχει ήδη δεδομένα.<br>\n";
 }
 
 $pdo->exec("CREATE TABLE IF NOT EXISTS workplaces (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(100) NOT NULL
 ) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+echo "Έλεγχος πίνακα workplaces...<br>\n";
 if (!$pdo->query('SELECT COUNT(*) FROM workplaces')->fetchColumn()) {
     $pdo->exec("INSERT INTO workplaces (name) VALUES ('Εντός ΔΑΑΘ'),('Εξωτερικό Συνεργείο'),('ΥΤΕΒΕ')");
+    echo "Προστέθηκαν default workplaces.<br>\n";
+} else {
+    echo "Ο πίνακας workplaces έχει ήδη δεδομένα.<br>\n";
 }
 
-echo 'Setup complete.';
+echo "Setup complete.<br>\n";
 ?>

--- a/www.technology.gr/coder/setup.php
+++ b/www.technology.gr/coder/setup.php
@@ -9,7 +9,12 @@ $sql = "CREATE TABLE IF NOT EXISTS car_jobs (
     employee VARCHAR(100) NOT NULL,
     workplace VARCHAR(50) NOT NULL,
     work_type VARCHAR(100) NOT NULL,
-    description TEXT
+    description TEXT,
+    next_service_date DATE DEFAULT NULL,
+    next_service_km INT DEFAULT NULL,
+    user_notes TEXT,
+    battery VARCHAR(3) NOT NULL DEFAULT 'ΟΧΙ',
+    tires VARCHAR(3) NOT NULL DEFAULT 'ΟΧΙ'
 ) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci";
 $pdo->exec($sql);
 

--- a/www.technology.gr/coder/setup.php
+++ b/www.technology.gr/coder/setup.php
@@ -1,0 +1,44 @@
+<?php
+require 'config.php';
+
+$sql = "CREATE TABLE IF NOT EXISTS car_jobs (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    movement_date DATE NOT NULL,
+    license VARCHAR(20) NOT NULL,
+    kilometers INT NOT NULL,
+    employee VARCHAR(100) NOT NULL,
+    workplace VARCHAR(50) NOT NULL,
+    work_type VARCHAR(100) NOT NULL,
+    description TEXT
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci";
+$pdo->exec($sql);
+
+$sql = "CREATE TABLE IF NOT EXISTS licenses (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(20) NOT NULL
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci";
+$pdo->exec($sql);
+if (!$pdo->query('SELECT COUNT(*) FROM licenses')->fetchColumn()) {
+    $pdo->exec("INSERT INTO licenses (name) VALUES ('11111'),('222222'),('333333')");
+}
+
+$sql = "CREATE TABLE IF NOT EXISTS employees (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci";
+$pdo->exec($sql);
+if (!$pdo->query('SELECT COUNT(*) FROM employees')->fetchColumn()) {
+    $pdo->exec("INSERT INTO employees (name) VALUES ('Υπάλληλος 1'),('Υπάλληλος 2'),('Υπάλληλος 3')");
+}
+
+$sql = "CREATE TABLE IF NOT EXISTS workplaces (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci";
+$pdo->exec($sql);
+if (!$pdo->query('SELECT COUNT(*) FROM workplaces')->fetchColumn()) {
+    $pdo->exec("INSERT INTO workplaces (name) VALUES ('Εντός ΔΑΑΘ'),('Εξωτερικό Συνεργείο'),('ΥΤΕΒΕ')");
+}
+
+echo "Tables created or already exist.";
+?>


### PR DESCRIPTION
## Summary
- create DB tables for licenses, employees and workplaces in setup
- add manage.php for CRUD on helper lists
- add helpers.php menu page
- fetch dropdown options from DB in record form
- link to helpers via a new navigation menu on the index page

## Testing
- `php -l www.technology.gr/coder/config.php`
- `php -l www.technology.gr/coder/index.php`
- `php -l www.technology.gr/coder/record.php`
- `php -l www.technology.gr/coder/export.php`
- `php -l www.technology.gr/coder/setup.php`
- `php -l www.technology.gr/coder/helpers.php`
- `php -l www.technology.gr/coder/manage.php`


------
https://chatgpt.com/codex/tasks/task_e_6872649a8254832888aae44882528b50